### PR TITLE
Feature/add members at creation

### DIFF
--- a/actions/read_projects_email_file.py
+++ b/actions/read_projects_email_file.py
@@ -23,9 +23,9 @@ class ReadProjectsEmailFile(Action):
             for row in reader:
                 project = row['project']
                 sensitive = self.str_to_bool(row['sensitive'])
+                members = [email.strip() for email in row.get('members', "").split(",") if len(email) > 0]
                 if project in projects_list:
-                    result[project] = {"email": row['email'],"sensitive": sensitive}
-                    
+                    result[project] = {"email": row['email'], "members": members, "sensitive": sensitive}
 
         if len(projects_list) == len(result.keys()):
             self.logger.info("Projects given and projects found in file did match...")

--- a/actions/supr.py
+++ b/actions/supr.py
@@ -40,10 +40,13 @@ class Supr(Action):
     def search_for_pis(project_to_email_dict, supr_base_api_url, api_user, api_key):
         res = {}
         for project, project_info in project_to_email_dict.iteritems():
-            res[project] = Supr.search_by_email(base_url=supr_base_api_url,
-                                                email=project_info['email'],
-                                                user=api_user,
-                                                key=api_key)
+            res[project] = map(
+                lambda e: Supr.search_by_email(
+                    base_url=supr_base_api_url,
+                    email=e,
+                    user=api_user,
+                    key=api_key),
+                project_info['email'].split(','))
         return res
 
     @staticmethod
@@ -51,7 +54,8 @@ class Supr(Action):
 
         result = {}
         for ngi_project_name in staging_info.keys():
-            pi_id = project_names_and_ids[ngi_project_name]
+            pi_id = project_names_and_ids[ngi_project_name][0]
+            member_ids = project_names_and_ids[ngi_project_name][1:]
 
             create_delivery_project_url = '{}/ngi_delivery/project/create/'.format(base_url)
 
@@ -67,6 +71,7 @@ class Supr(Action):
                 'ngi_project_name': ngi_project_name,
                 'title': "DELIVERY_{}_{}".format(ngi_project_name, today_formatted),
                 'pi_id': pi_id,
+                'member_ids': member_ids,
                 'start_date': today_formatted,
                 'end_date': three_months_from_now_formatted,
                 'continuation_name': '',

--- a/actions/supr.py
+++ b/actions/supr.py
@@ -37,16 +37,17 @@ class Supr(Action):
         return matches[0]["id"]
 
     @staticmethod
-    def search_for_pis(project_to_email_dict, supr_base_api_url, api_user, api_key):
+    def search_by_emails(base_url, emails, user, key):
+        return map(lambda email: Supr.search_by_email(base_url=base_url, email=email, user=user, key=key), emails)
+
+    @staticmethod
+    def search_for_pi_and_members(project_to_email_dict, supr_base_api_url, api_user, api_key):
         res = {}
         for project, project_info in project_to_email_dict.iteritems():
-            res[project] = map(
-                lambda e: Supr.search_by_email(
-                    base_url=supr_base_api_url,
-                    email=e,
-                    user=api_user,
-                    key=api_key),
-                project_info['email'].split(','))
+            res[project] = {"pi_id": Supr.search_by_email(
+                base_url=supr_base_api_url, email=project_info['email'], user=api_user, key=api_key),
+                            "member_ids": Supr.search_by_emails(
+                base_url=supr_base_api_url, emails=project_info['members'], user=api_user, key=api_key)}
         return res
 
     @staticmethod
@@ -54,8 +55,8 @@ class Supr(Action):
 
         result = {}
         for ngi_project_name in staging_info.keys():
-            pi_id = project_names_and_ids[ngi_project_name][0]
-            member_ids = project_names_and_ids[ngi_project_name][1:]
+            pi_id = project_names_and_ids[ngi_project_name]['pi_id']
+            member_ids = project_names_and_ids[ngi_project_name]['member_ids']
 
             create_delivery_project_url = '{}/ngi_delivery/project/create/'.format(base_url)
 

--- a/tests/test_read_projects_email_file.py
+++ b/tests/test_read_projects_email_file.py
@@ -1,0 +1,88 @@
+import csv
+import os
+import tempfile
+
+from st2tests.base import BaseActionTestCase
+from read_projects_email_file import ReadProjectsEmailFile
+
+
+class ReadProjectsEmailFileTestCase(BaseActionTestCase):
+    action_cls = ReadProjectsEmailFile
+
+    projects_email_file = None
+    project_emails = {
+        "AA-0001": {"email": "this.is.a.pi@email.com", "sensitive": False},
+        "BB-0002": {"email": "this.is.a.pi@email.com", "sensitive": True},
+        "CC-0003": {"email": "this.is.a.pi@email.com,this.is.member.1@email.com", "sensitive": False},
+        "DD-0004": {"email": "this.is.a.pi@email.com,this.is.member.1@email.com,this.is.member.2@email.com",
+                    "sensitive": True}
+    }
+
+    class MockPostResponse:
+        def __init__(self, response_link):
+            self.response_link = response_link
+
+        def json(self):
+            return {'link': self.response_link}
+
+    class MockStatusResponse:
+        def __init__(self, state_list):
+            self.state_list = state_list
+
+        # Every time we get new json, pop it from the beginning
+        # of the list. This way we can vary state over time.
+        def json(self):
+            return {"state": self.state_list.pop(0)}
+
+    @classmethod
+    def setUpClass(cls):
+        # write some content to a project email file
+        fd, projects_email_file = tempfile.mkstemp(suffix=".csv", prefix="test_read_projects_email_file")
+        with os.fdopen(fd) as csvh:
+            csv_writer = csv.DictWriter(csvh, delimiter=";", fieldnames=["project", "email", "sensitive"])
+            csv_writer.writeheader()
+            for proj, email in cls.project_emails.items():
+                row = dict(email)
+                row["project"] = proj
+                csv_writer.writerow(row)
+        cls.projects_email_file = projects_email_file
+
+    def run_with_params(self, expected_exit_status, expected_result, *args):
+        observed_exit_status, observed_result = self.get_action_instance().run(self.projects_email_file, *args)
+        self.assertTrue(observed_exit_status == expected_exit_status)
+        self.assertDictEqual(expected_result, observed_result)
+
+    def test_run_with_all_projects(self):
+        expected_exit_status = True
+        expected_result = self.project_emails
+        self.run_with_params(
+            expected_exit_status,
+            expected_result,
+            {"projects": expected_result.keys()},
+            "keep_all_projects")
+
+    def test_run_with_some_projects(self):
+        restrict_to_projects = "AA-0001,DD-0004"
+        expected_exit_status = True
+        expected_result = {
+            proj: email for proj, email in self.project_emails.items() if proj in restrict_to_projects.split(",")}
+        self.run_with_params(
+            expected_exit_status,
+            expected_result,
+            {"projects": expected_result.keys()},
+            restrict_to_projects)
+
+    def test_run_with_missing_project(self):
+        expected_exit_status = False
+        expected_result = {}
+        self.run_with_params(
+            expected_exit_status,
+            expected_result,
+            {"projects": "this-project-is-not-in-file"},
+            "keep_all_projects")
+
+    def test_str_to_bool(self):
+        for exp in (True, False):
+            self.assertEqual(exp, self.get_action_instance().str_to_bool(str(exp)))
+        with self.assertRaises(ValueError):
+            self.get_action_instance().str_to_bool("Not a bool")

--- a/tests/test_read_projects_email_file.py
+++ b/tests/test_read_projects_email_file.py
@@ -18,22 +18,6 @@ class ReadProjectsEmailFileTestCase(BaseActionTestCase):
                     "sensitive": True}
     }
 
-    class MockPostResponse:
-        def __init__(self, response_link):
-            self.response_link = response_link
-
-        def json(self):
-            return {'link': self.response_link}
-
-    class MockStatusResponse:
-        def __init__(self, state_list):
-            self.state_list = state_list
-
-        # Every time we get new json, pop it from the beginning
-        # of the list. This way we can vary state over time.
-        def json(self):
-            return {"state": self.state_list.pop(0)}
-
     @classmethod
     def setUpClass(cls):
         # write some content to a project email file

--- a/tests/test_read_projects_email_file.py
+++ b/tests/test_read_projects_email_file.py
@@ -11,11 +11,11 @@ class ReadProjectsEmailFileTestCase(BaseActionTestCase):
 
     projects_email_file = None
     project_emails = {
-        "AA-0001": {"email": "this.is.a.pi@email.com", "sensitive": False},
-        "BB-0002": {"email": "this.is.a.pi@email.com", "sensitive": True},
-        "CC-0003": {"email": "this.is.a.pi@email.com,this.is.member.1@email.com", "sensitive": False},
-        "DD-0004": {"email": "this.is.a.pi@email.com,this.is.member.1@email.com,this.is.member.2@email.com",
-                    "sensitive": True}
+        "AA-0001": {"email": "this.is.a.pi@email.com", "sensitive": False, "members": []},
+        "BB-0002": {"email": "this.is.a.pi@email.com", "sensitive": True, "members": []},
+        "CC-0003": {"email": "this.is.a.pi@email.com", "sensitive": False, "members": ["this.is.member.1@email.com"]},
+        "DD-0004": {"email": "this.is.a.pi@email.com", "sensitive": True,
+                    "members": ["this.is.member.1@email.com", "this.is.member.2@email.com"]}
     }
 
     @classmethod
@@ -23,11 +23,12 @@ class ReadProjectsEmailFileTestCase(BaseActionTestCase):
         # write some content to a project email file
         fd, projects_email_file = tempfile.mkstemp(suffix=".csv", prefix="test_read_projects_email_file")
         with os.fdopen(fd) as csvh:
-            csv_writer = csv.DictWriter(csvh, delimiter=";", fieldnames=["project", "email", "sensitive"])
+            csv_writer = csv.DictWriter(csvh, delimiter=";", fieldnames=["project", "email", "members", "sensitive"])
             csv_writer.writeheader()
             for proj, email in cls.project_emails.items():
                 row = dict(email)
                 row["project"] = proj
+                row["members"] = ",".join(email["members"])
                 csv_writer.writerow(row)
         cls.projects_email_file = projects_email_file
 

--- a/tests/test_supr.py
+++ b/tests/test_supr.py
@@ -1,0 +1,98 @@
+import mock
+import json
+
+import supr
+from st2tests.base import BaseActionTestCase
+
+
+class SuprTestCase(BaseActionTestCase):
+    action_cls = supr.Supr
+
+    class MockPostResponse:
+        def __init__(self, content, status_code=200):
+            self.content = content
+            self.status_code = status_code
+
+    def setUp(self):
+        self.supr_base_url = "this-is-the-supr-base-url"
+        self.api_user = "this-is-the-api-user"
+        self.api_key = "this-is-the-api-key"
+        self.project_to_email_dict = {
+            "AA-0001": {"email": "this.is.a.pi@email.com", "sensitive": False},
+            "BB-0002": {"email": "this.is.a.pi@email.com", "sensitive": True},
+            "CC-0003": {"email": "this.is.a.pi@email.com,this.is.member.1@email.com", "sensitive": False},
+            "DD-0004": {"email": "this.is.a.pi@email.com,this.is.member.1@email.com,this.is.member.2@email.com",
+                        "sensitive": True}
+        }
+        self.expected_project_pi_ids = self.project_pi_ids()
+
+    @staticmethod
+    def mock_pi_id(**kwargs):
+        # as a simple str->int conversion, just sum the ascii values for the characters in email
+        return sum((ord(c) for c in kwargs["email"]))
+
+    @staticmethod
+    def post_mock_reponse(*args, **kwargs):
+        return SuprTestCase.MockPostResponse(json.dumps(kwargs["data"]))
+
+    def project_pi_ids(self):
+        return {
+            proj: map(
+                lambda x: SuprTestCase.mock_pi_id(email=x),
+                proj_info["email"].split(","))
+            for proj, proj_info in self.project_to_email_dict.items()
+        }
+
+    def setup_and_run_create_delivery_project(self):
+        project_names_and_ids = self.expected_project_pi_ids
+        staging_info = {proj: {"size": 1e12} for proj in self.project_to_email_dict.keys()}
+        project_info = dict(self.project_to_email_dict)
+        return [
+            supr.Supr.create_delivery_project(
+                self.supr_base_url, project_names_and_ids, staging_info, project_info, self.api_user, self.api_key),
+            project_names_and_ids,
+            staging_info,
+            project_info]
+
+    def test_create_delivery_project(self):
+        with mock.patch.object(
+            supr.requests,
+            'post',
+            side_effect=SuprTestCase.post_mock_reponse
+        ) as post_mock:
+            observed_delivery_projects, project_names_and_ids, staging_info, project_info = \
+                self.setup_and_run_create_delivery_project()
+            self.assertListEqual(sorted(observed_delivery_projects.keys()), sorted(staging_info.keys()))
+            for proj in project_names_and_ids.keys():
+                observed_content = json.loads(observed_delivery_projects[proj])
+                self.assertEqual(observed_content["pi_id"], project_names_and_ids[proj][0])
+                self.assertListEqual(observed_content["member_ids"], project_names_and_ids[proj][1:])
+                self.assertEqual(observed_content["ngi_sensitive_data"], project_info[proj]["sensitive"])
+
+    def test_create_delivery_project_fail(self):
+        with mock.patch.object(
+            supr.requests,
+            'post',
+            return_value=SuprTestCase.MockPostResponse("some fail content", status_code=400)
+        ) as post_mock:
+            with self.assertRaises(AssertionError) as ae:
+                self.setup_and_run_create_delivery_project()
+
+    def test_search_for_pis(self):
+        with mock.patch.object(
+                supr.Supr, "search_by_email", side_effect=SuprTestCase.mock_pi_id) as search_mock:
+            observed_pi_ids = supr.Supr.search_for_pis(
+                self.project_to_email_dict,
+                self.supr_base_url,
+                self.api_user,
+                self.api_key)
+            self.assertDictEqual(observed_pi_ids, self.expected_project_pi_ids)
+            self.assertEqual(
+                search_mock.call_count,
+                sum((len(values) for values in self.expected_project_pi_ids.values())))
+            calls = [
+                mock.call(base_url=self.supr_base_url, email=email, user=self.api_user, key=self.api_key)
+                for project_info in self.project_to_email_dict.values()
+                for email in project_info["email"].split(",")
+            ]
+            search_mock.assert_has_calls(calls, any_order=True)


### PR DESCRIPTION
- In addition to the PI, additional members can be added to the delivery project at creation time
- PI and member email addresses are specified as a comma-separated list in the the projects email file. The first address in the list will be the PI.
- Some unit tests added