### PR TITLE
rule, action and workflow for fetching project reports to summary host

### DIFF
--- a/actions/gather_project_reports.yaml
+++ b/actions/gather_project_reports.yaml
@@ -1,0 +1,20 @@
+---
+name: gather_project_reports
+description: Sync project reports from Irma to the summary host
+enabled: true
+runner_type: mistral-v2
+entry_point: workflows/gather_project_reports.yaml
+pack: arteria-packs
+parameters:
+  context:
+    default: {}
+    immutable: true
+    type: object
+  workflow:
+    default: arteria-packs.gather_project_reports
+    immutable: true
+    type: string
+  year:
+    default: -1
+    type: integer
+    description: Set to override default of using current year to the year set. This effects which folders are checked.

--- a/actions/workflows/gather_project_reports.yaml
+++ b/actions/workflows/gather_project_reports.yaml
@@ -1,0 +1,71 @@
+version: "2.0" # mistral version
+name: arteria-packs.gather_project_reports
+description: Downloads summary statistics data from irma.
+
+workflows:
+    main:
+        type: direct
+        input:
+          - year
+
+        tasks:
+            note_workflow_version:
+              action: core.local
+              input:
+                cmd: git rev-parse HEAD
+                cwd: /opt/stackstorm/packs/arteria-packs/
+              on-success:
+                  - get_config
+
+            get_config:
+              action: arteria-packs.get_pack_config
+              publish:
+                summary_host: <% task(get_config).result.result.summary_host %>
+                summary_user: <% task(get_config).result.result.summary_user %>
+                summary_host_key: <% task(get_config).result.result.summary_host_key %>
+                summary_destination: <% task(get_config).result.result.summary_destination %>
+                irma_remote_path: <% task(get_config).result.result.irma_remote_path %>
+              on-success:
+                 - get_year
+
+            get_year:
+              action: core.local
+              input:
+                # -1 is the default value of year - indicating that the current year should be used
+                cmd: if [ -1 -eq <% $.year %> ]; then date +%Y; else echo <% $.year %>; fi
+              publish:
+                current_year: <% task(get_year).result.stdout %>
+              on-success:
+                - check_for_runfolders
+
+            check_for_runfolders:
+              action: arteria-packs.get_remote_folder_list
+              input:
+                directory: <% $.summary_destination %>/<% $.current_year %>/
+                username: <% $.summary_user %>
+                hosts: <% $.summary_host %>
+                private_key: <% $.summary_host_key %>
+              publish:
+                runfolders: <% task(check_for_runfolders).result.get($.summary_host).stdout %>
+              on-success:
+                - rsync_from_irma
+
+            rsync_from_irma:
+              action: core.remote
+              with-items: runfolder in <% $.runfolders %>
+              input:
+                # Note:
+                # - that modtimes are preserved here so that we can check downstream
+                #   that required files are old enough.
+                # - that this will always return 0 exit status and that this is a potential source or problems.
+                #   Since we cannot know before hand if a report directory exists or not, we will attempt to transfer
+                #   regardless of this. If this fails (and rsync returns code 23) we will ignore this, and this might
+                #   potentially leading to us missing real errors.
+                # - Filtering for downstream insertion into the database is carried out by the check_reports_old_enough
+                #   which will only return the runfolders with valid summary reports for processing.
+                cmd: rsync -e "ssh -i /home/seqsum/.ssh/mm-xlas002" -r --times funk_901@irma1.uppmax.uu.se:<% $.irma_remote_path %>/<% $.runfolder %>/Summary <% $.summary_destination %>/<% $.current_year %>/<% $.runfolder %>/; if (( $? == 0 || $? == 23 )) ; then true; else false; fi
+                hosts: <% $.summary_host %>
+                username: <% $.summary_user %>
+                private_key: <% $.summary_host_key %>
+                timeout: 18000 # 5 h timeout
+              concurrency: 5

--- a/rules/gather_project_reports.yaml
+++ b/rules/gather_project_reports.yaml
@@ -1,0 +1,14 @@
+---
+name: "arteria-packs.gather_project_reports"
+pack: "arteria-packs"
+description: "Sync project reports from Irma to the summary host at the set intervals."
+enabled: true
+
+trigger:
+    type: "core.st2.IntervalTimer"
+    parameters:
+      unit: hours
+      delta: 2
+
+action:
+    ref: "arteria-packs.gather_project_reports"


### PR DESCRIPTION
**What problems does this PR solve?**
When removing the Perl script and associated action for filling ProjMan, the sync of summary reports from Irma also stopped. This PR re-introduces the syncing of reports but without filling ProjMan.

**How has the changes been tested?**
Action has been tested and run successfully from arteria-staging.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
