### PR TITLE
pull mongodb 3.2 from docker for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
 language: python
 python: 2.7
-sudo: false
+sudo: required
 os:
   - linux
 services:
   # Note: MongoDB and RabbitMQ is needed for packs-resource-register check
-  - mongodb
+  - docker
   - rabbitmq
 addons:
   apt:
     packages:
       - git
+before_install:
+  - docker pull mongo
+  - docker run -d -p 0.0.0.0:27017:27017 --name st2-mongo mongo:3.2
 install:
   - virtualenv venv
   - source venv/bin/activate && pip install --upgrade pip


### PR DESCRIPTION
**What problems does this PR solve?**
The Travis-CI builds were failing, presumably because Travis has moved to using MongoDB 3.4, which enforces some stricter checks on indexes etc. This PR runs MongoDB 3.2 in Travis-CI through docker instead.

**How has the changes been tested?**
Running the Travis-CI build and make sure it passes.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
