### PR TITLE
New Stackstorm workflows for running archive verifications 

### DIFF
--- a/actions/archive_remove.yaml
+++ b/actions/archive_remove.yaml
@@ -1,0 +1,22 @@
+---
+name: archive_remove
+description: >
+  Removes archives previously verified OK.
+enabled: true
+runner_type: mistral-v2
+entry_point: workflows/archive_remove.yaml
+pack: arteria-packs
+parameters:
+  context:
+    default: {}
+    immutable: true
+    type: object
+  workflow:
+    default: arteria-packs.archive_remove
+    immutable: true
+    type: string
+  host:
+    description: 'Host where the archives are located'
+    required: true
+    type: string
+    default: "all"

--- a/actions/archive_set_removable.yaml
+++ b/actions/archive_set_removable.yaml
@@ -1,0 +1,22 @@
+---
+name: archive_set_removable
+description: >
+  Mark an archive as removable in the db.
+enabled: true
+runner_type: mistral-v2
+entry_point: workflows/archive_set_removable.yaml
+pack: arteria-packs
+parameters:
+  context:
+    default: {}
+    immutable: true
+    type: object
+  workflow:
+    default: arteria-packs.archive_set_removable
+    immutable: true
+    type: string
+  description:
+    description: 'The unique TSM description used when uploading the archive to PDC.'
+    required: true
+    type: string
+    default: "all"

--- a/actions/archive_verify_random.yaml
+++ b/actions/archive_verify_random.yaml
@@ -1,0 +1,17 @@
+---
+name: archive_verify_random
+description: >
+  Verifies the checksums for a randomly picked runfolder archive that has been uploaded to PDC. The choice is made among all the nonverified archives that has been uploaded within a specific time window. 
+enabled: true
+runner_type: mistral-v2
+entry_point: workflows/archive_verify_random.yaml
+pack: arteria-packs
+parameters:
+  context:
+    default: {}
+    immutable: true
+    type: object
+  workflow:
+    default: arteria-packs.archive_verify_random
+    immutable: true
+    type: string

--- a/actions/archive_verify_specific.yaml
+++ b/actions/archive_verify_specific.yaml
@@ -1,0 +1,34 @@
+---
+name: archive_verify_specific
+description: >
+  Verifies the checksums for a specific runfolder archive that has been uploaded to PDC
+enabled: true
+runner_type: mistral-v2
+entry_point: workflows/archive_verify_specific.yaml
+pack: arteria-packs
+parameters:
+  context:
+    default: {}
+    immutable: true
+    type: object
+  workflow:
+    default: arteria-packs.archive_verify_specific
+    immutable: true
+    type: string
+  host:
+    description: 'Host from where archive was uploaded'
+    required: true
+    type: string
+  archive:
+    description: 'Archive to verify'
+    required: true
+    type: string
+  description: 
+    description: 'Unique description used when uploading archive to PDC'
+    required: true
+    type: string
+#  remove_previous_archive:
+#    description: 'Set to true to remove previous archive'
+#    required: true
+#    type: boolean
+#    default: false

--- a/actions/archive_verify_specific.yaml
+++ b/actions/archive_verify_specific.yaml
@@ -27,8 +27,3 @@ parameters:
     description: 'Unique description used when uploading archive to PDC'
     required: true
     type: string
-#  remove_previous_archive:
-#    description: 'Set to true to remove previous archive'
-#    required: true
-#    type: boolean
-#    default: false

--- a/actions/parse_archive_verify_args.yaml
+++ b/actions/parse_archive_verify_args.yaml
@@ -1,0 +1,22 @@
+---
+name: parse_archive_verify_args
+runner_type: python-script
+description: Parses archive verify args to json
+enabled: true
+entry_point: lib/parse_arguments_to_json.py
+parameters:
+
+  archive:
+    default: ""
+    type: string
+    description: "Name of runfolder archive uploaded."
+
+  description:
+    default: ""
+    type: string
+    description: "Unique description used when uploading the archive."
+
+  host:
+    default: ""
+    type: string
+    description: "Host from where the archive was uploaded." 

--- a/actions/poll_status-archive.py
+++ b/actions/poll_status-archive.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+
+import datetime
+import time
+from urlparse import urlparse
+
+import requests
+
+from requests.exceptions import RequestException, HTTPError
+
+# Needs to be run in a Stackstorm virtualenv
+from st2actions.runners.pythonrunner import Action
+
+class PollStatus(Action):
+    """
+    Polls a give micro service URL for current status of some long running process.
+    Will check the HTTP server's response to determine whether or not the process has finished
+    processing. It expects a JSON field called "state", and will continue to poll the URL
+    as long as "state" equals "started". If e.g. "done", "error", or "none" is received an
+    error is generated and the polling stops.
+    """
+
+    def query(self, url, verify_ssl_cert):
+        try:
+            resp = requests.get(url, verify=verify_ssl_cert)
+            resp.raise_for_status()
+            return resp
+        except RequestException as err:
+            self.logger.error("An error was encountered when "
+                              "querying url: {0},  {1}".format(url, err))
+            raise err
+        except HTTPError as err:
+            self.logger.error("An error was encountered when querying the url {}: {}".format(url, err))            
+
+    def post_to_endpoint(self, endpoint, body, irma_mode, verify_ssl_cert):
+
+        def _rewrite_link(link):
+            endpoint_parsed = urlparse(endpoint)
+            # Gets the first non-empty element from the path, this lets it account
+            # for multiple slashes
+            first_part_of_path = filter(None, endpoint_parsed.path.split('/'))[0]
+            link_parsed = urlparse(link)
+            return "{}://{}/{}{}?{}".format(endpoint_parsed.scheme,
+                                            endpoint_parsed.netloc,
+                                            first_part_of_path,
+                                            link_parsed.path,
+                                            endpoint_parsed.query)
+
+        try:
+            response = requests.post(endpoint, json=body, verify=verify_ssl_cert)
+            response.raise_for_status()
+            response_json = response.json()
+
+            if irma_mode:
+                modified_link = _rewrite_link(response_json['link'])
+                self.logger.info("In irma mode, will rewrite link to: {}".format(modified_link))
+                return {"response": response_json, "url": modified_link}
+            else:
+                return {"response": response_json, "url": response_json['link']}
+        except HTTPError as err:
+            self.logger.error("An error was encountered when trying to post to url {}: {}".format(endpoint, err))
+        except RequestException as err:
+            self.logger.error("An error was encountered when trying to "
+                                "post to url: {0}, {1}".format(endpoint, err))
+            raise err
+        except KeyError as err:
+            self.logger.error("Could not find correct key in response json: {}".format(response_json))
+            raise err
+        except ValueError as err:
+            self.logger.error("Error decoding response as json. Got status: {} and response: {}".format(
+                response.status_code,
+                response.content))
+            raise err
+
+    def check_status(self, url, sleep, ignore_result, verify_ssl_cert, max_retries):
+        """
+        Query the url end-point. Can be called directly from StackStorm, or via the script cli
+        :param url: to call
+        :param sleep: minutes to sleep between attempts
+        :param ignore_result: return 0 exit status even if polling failed (for known errors).
+        :param verify_ssl_cert: Set to False to skip verifying the ssl cert when making requests
+        :param max_retries: maximum number of retries
+        :return: None
+        """
+        retry_attempts = 0
+        state = "started"
+
+        while state == "started" or state == "pending" or not state:
+            current_time = datetime.datetime.now()
+
+            resp = self.query(url, verify_ssl_cert)
+            json_resp = resp.json()
+            state = json_resp["state"]
+
+            if state == "started" or state == "pending":
+                self.logger.info("{0} -- {1} returned state {2}. Sleeping {3}m until retrying again...".format(current_time,
+                                                                                                               url,
+                                                                                                               state,
+                                                                                                               sleep))
+                time.sleep(sleep * 60)
+            elif state == "done":
+                self.logger.info("{0} -- {1} returned state {2}. Will now stop polling the status.".format(current_time,
+                                                                                                           url,
+                                                                                                           state))
+
+                return True, json_resp
+            elif state in ["error", "none", "cancelled"]:
+                self.logger.warning("{0} -- {1} returned state {2}. Will now stop polling the status.".format(current_time,
+                                                                                                              url,
+                                                                                                              state))
+
+                if ignore_result:
+                    self.logger.warning("Ignoring the failed result because of override flag.")
+                    return True, json_resp
+                else:
+                    return False, json_resp
+
+            elif not state and retry_attempts < max_retries:
+                retry_attempts += 1
+                self.logger.warning("{0} -- {1} did not report state. "
+                                    "Probably due to a connection error, "
+                                    "will retry. Attempt {2} of {3}.".format(current_time,
+                                                                             url,
+                                                                             retry_attempts,
+                                                                             max_retries))
+                time.sleep(sleep * 60)
+            else:
+                self.logger.error("{0} -- {1} returned state unknown state {2}. "
+                                  "Will now stop polling the status.".format(current_time, url, state))
+                return False, json_resp
+
+    def run(self, url, body, sleep, ignore_result, irma_mode, verify_ssl_cert, max_retries=3):
+        start_response = self.post_to_endpoint(url, body, irma_mode, verify_ssl_cert)
+        status_link = start_response['url']
+        status_val, status_response = self.check_status(status_link, sleep, ignore_result, verify_ssl_cert, max_retries)
+        return status_val, { "response_from_start": start_response, "response_from_last_status_check": status_response }

--- a/actions/poll_status-archive.yaml
+++ b/actions/poll_status-archive.yaml
@@ -1,0 +1,38 @@
+---
+name: poll_status-archive
+runner_type: run-python
+description: Posts data to a url starting a process, and polls the status link it gets back until it finishes or fails.
+enabled: true
+entry_point: poll_status-archive.py
+parameters:
+    timeout:
+        # Use a default timeout of 24 hour. "No timout" is fixed in a new version
+        # https://github.com/StackStorm/st2/issues/1654
+        default: 86400
+    url:
+        type: string
+        description: URL you want to post the data to for current status of long running process
+        required: true
+    sleep:
+        type: integer
+        description: Number of minutes to sleep between poll retries (default 1 m)
+        required: false
+        default: 1
+    body:
+        type: object
+        description: The json data to post to the url.
+    ignore_result:
+        type: boolean
+        description: Allows manually overriding the result, e.g. even script will return 0 exit status even if polling failed. Useful for e.g. overriding qc result checking.
+        required: false
+        default: false
+    irma_mode:
+        type: boolean
+        description: Services on irma live behind a gateway and will therefore return incorrect links. Setting this to true will rewrite those links
+        required: false
+        default: false
+    verify_ssl_cert:
+        type: boolean
+        description: Verify the ssl cert if using https, default is true.
+        required: false
+        default: true

--- a/actions/workflows/archive_remove.yaml
+++ b/actions/workflows/archive_remove.yaml
@@ -1,0 +1,71 @@
+version: "2.0" # mistral version
+name: arteria-packs.archive_remove
+description: Removes archives previously verified OK.
+
+workflows:
+    main:
+        type: direct
+        input:
+            - host
+        output:
+            output_the_whole_workflow_context: <% $ %>
+        task-defaults:
+          on-error:
+            - notify_failure_on_slack
+
+        tasks:
+            ### GENERAL TASKS START ###
+            note_workflow_repo_version:
+              action: core.local
+              input:
+                cmd: git rev-parse HEAD
+                cwd: /opt/stackstorm/packs/arteria-packs/
+              on-success:
+                - get_config
+
+            get_config:
+              action: arteria-packs.get_pack_config
+              publish:
+                archive_remove_port: <% task(get_config).result.result.archive_remove_service_port %>
+                archive_status_slack_channel: <% task(get_config).result.result.archive_status_slack_channel %>
+                archive_db_base_url: <% task(get_config).result.result.archive_db_base_url %>
+              on-success:
+                - get_archives_to_remove
+
+            ### GENERAL TASKS END ###
+
+            ### TSM ARCHIVE REMOVE START ###
+
+            get_archives_to_remove:
+                action: core.http
+                input:
+                  url: <% $.archive_db_base_url %>/
+                  body: '{ "description": "<% $.description %>", "host": "<% $.host %>", "path": "<% $.archive_path %>" }'
+                  method: "POST"
+                  timeout: 60
+                on-success:
+                  - notify_success_on_slack
+
+            notify_success_on_slack:
+              action: arteria-packs.post_to_slack
+              input:
+                user: "I, Archivian"
+                emoji_icon: ":robot_face:"
+                channel: <% $.archive_status_slack_channel %>
+                message: "Successfully verified MD5 sums for archive `<% $.archive_path %>`. See details with `st2 execution get <% env().st2_execution_id %>`"
+
+            ### END TSM ARCHIVE REMOVE ###
+
+            ## NOTIFIER START ###
+
+            notify_failure_on_slack:
+               action: arteria-packs.post_to_slack
+               input:
+                 user: 'I, Archivian'
+                 emoji_icon: ':robot_face:'
+                 channel: <% $.archive_status_slack_channel %>
+                 message: 'Unfortunately an error occurred when trying to verify archive `<% $.archive %>` uploaded from `<% $.host %>`. You can see more details by running: `st2 execution get <% env().st2_execution_id %>`'
+               on-complete:
+                 - fail
+
+            ### NOTIFIER END ###

--- a/actions/workflows/archive_set_removable.yaml
+++ b/actions/workflows/archive_set_removable.yaml
@@ -1,0 +1,76 @@
+version: "2.0" # mistral version
+name: arteria-packs.archive_set_removable
+description: Mark an archive as removable in the db.
+
+workflows:
+    main:
+        type: direct
+        input:
+            - description
+        output:
+            output_the_whole_workflow_context: <% $ %>
+        task-defaults:
+          on-error:
+            - notify_failure_on_slack
+
+        tasks:
+            ### GENERAL TASKS START ###
+            note_workflow_repo_version:
+              action: core.local
+              input:
+                cmd: git rev-parse HEAD
+                cwd: /opt/stackstorm/packs/arteria-packs/
+              on-success:
+                - get_config
+
+            get_config:
+              action: arteria-packs.get_pack_config
+              publish:
+#                archive_remove_port: <% task(get_config).result.result.archive_remove_service_port %>
+#                archive_remove_base_url: <% task(get_config).result.result.archive_remove_base_url %>
+                archive_status_slack_channel: <% task(get_config).result.result.archive_status_slack_channel %>
+                archive_db_base_url: <% task(get_config).result.result.archive_db_base_url %>
+              on-success:
+                - mark_as_removable_in_db
+
+            ### GENERAL TASKS END ###
+
+            ### TSM ARCHIVE MARK REMOVABLE START ###
+
+            mark_as_removable_in_db:
+                action: core.http
+                input:
+                  url: <% $.archive_db_base_url %>/removal
+                  body: '{ "description": "<% $.description %>", "action": "set_removable" }'
+                  method: "POST"
+                  timeout: 30
+                publish:
+                  archive_name: <% task(mark_as_removable_in_db).result.body.archive.path %>
+                  archive_host: <% task(mark_as_removable_in_db).result.body.archive.host %>
+                  archive_description: <% task(mark_as_removable_in_db).result.body.archive.description %>
+                on-success:
+                  - notify_success_on_slack
+
+            notify_success_on_slack:
+              action: arteria-packs.post_to_slack
+              input:
+                user: "I, Archivian"
+                emoji_icon: ":robot_face:"
+                channel: <% $.archive_status_slack_channel %>
+                message: "I have now scheduled archive `<% $.archive_path %>`, with description `<% $.archive_description %>,` on `<% $.archive_host %>` for removal. See details with `st2 execution get <% env().st2_execution_id %>`"
+
+            ### END TSM ARCHIVE MARK REMOVABLE ###
+
+            ## NOTIFIER START ###
+
+            notify_failure_on_slack:
+               action: arteria-packs.post_to_slack
+               input:
+                 user: 'I, Archivian'
+                 emoji_icon: ':robot_face:'
+                 channel: <% $.archive_status_slack_channel %>
+                 message: 'Unfortunately an error occurred when trying to mark the archive with description `<% $.description %>` for removal. You can see more details by running: `st2 execution get <% env().st2_execution_id %>`'
+               on-complete:
+                 - fail
+
+            ### NOTIFIER END ###

--- a/actions/workflows/archive_verify_random.yaml
+++ b/actions/workflows/archive_verify_random.yaml
@@ -1,6 +1,6 @@
 version: "2.0" # mistral version
 name: arteria-packs.archive_verify_random
-description: Verify a randomly picked runfolder archive that was uploaded to PDC. Supposed to be run each week. Picks a runfolder that has not been verified previously, and was uploaded within the interval [1 week ago, yesterday].  
+description: Verify a randomly picked runfolder archive that was uploaded to PDC. Supposed to be run each week. Picks a runfolder that has not been verified previously, and was uploaded within the interval [1 week ago, yesterday].
 
 workflows:
     main:
@@ -35,23 +35,23 @@ workflows:
 
             ### TSM ARCHIVE VERIFY START ###
 
-            get_random_archive_to_verify: 
+            get_random_archive_to_verify:
               action: core.http
-              input: 
+              input:
                 url: <% $.archive_db_base_url %>/randomarchive
                 body: '{"safety_margin": "<% $.archive_safety_margin %>", "age": "<% $.archive_lookback_window %>"}'
-                method: "POST"
+                method: "GET"
                 timeout: 30
-              publish: 
+              publish:
                 archive_name: <% task(get_random_archive_to_verify).result.body.archive.archive %>
                 archive_host: <% task(get_random_archive_to_verify).result.body.archive.host %>
                 archive_description: <% task(get_random_archive_to_verify).result.body.archive.description %>
               on-success:
                 - verify_archive
 
-            verify_archive: 
+            verify_archive:
               action: arteria-packs.archive_verify_specific
-              input: 
+              input:
                 archive: <% $.archive_name %>
                 host: <% $.archive_host %>
                 description: <% $.archive_description %>

--- a/actions/workflows/archive_verify_random.yaml
+++ b/actions/workflows/archive_verify_random.yaml
@@ -1,0 +1,73 @@
+version: "2.0" # mistral version
+name: arteria-packs.archive_verify_random
+description: Verify a randomly picked runfolder archive that was uploaded to PDC. Supposed to be run each week. Picks a runfolder that has not been verified previously, and was uploaded within the interval [1 week ago, yesterday].  
+
+workflows:
+    main:
+        type: direct
+        output:
+            output_the_whole_workflow_context: <% $ %>
+        task-defaults:
+          on-error:
+            - notify_failure_on_slack
+
+        tasks:
+            ### GENERAL TASKS START ###
+            note_workflow_repo_version:
+              action: core.local
+              input:
+                cmd: git rev-parse HEAD
+                cwd: /opt/stackstorm/packs/arteria-packs/
+              on-success:
+                - get_config
+
+            get_config:
+              action: arteria-packs.get_pack_config
+              publish:
+                archive_status_slack_channel: <% task(get_config).result.result.archive_status_slack_channel %>
+                archive_db_base_url: <% task(get_config).result.result.archive_db_base_url %>
+                archive_safety_margin: <% task(get_config).result.result.archive_db_verify_safety_margin %>
+                archive_lookback_window: <% task(get_config).result.result.archive_db_verify_lookback_window %>
+              on-success:
+                - get_random_archive_to_verify
+
+            ### GENERAL TASKS END ###
+
+            ### TSM ARCHIVE VERIFY START ###
+
+            get_random_archive_to_verify: 
+              action: core.http
+              input: 
+                url: <% $.archive_db_base_url %>/randomarchive
+                body: '{"safety_margin": "<% $.archive_safety_margin %>", "age": "<% $.archive_lookback_window %>"}'
+                method: "POST"
+                timeout: 30
+              publish: 
+                archive_name: <% task(get_random_archive_to_verify).result.body.archive.archive %>
+                archive_host: <% task(get_random_archive_to_verify).result.body.archive.host %>
+                archive_description: <% task(get_random_archive_to_verify).result.body.archive.description %>
+              on-success:
+                - verify_archive
+
+            verify_archive: 
+              action: arteria-packs.archive_verify_specific
+              input: 
+                archive: <% $.archive_name %>
+                host: <% $.archive_host %>
+                description: <% $.archive_description %>
+
+            ### END TSM ARCHIVE VERIFY ###
+
+            ## NOTIFIER START ###
+
+            notify_failure_on_slack:
+               action: arteria-packs.post_to_slack
+               input:
+                 user: 'I, Archivian'
+                 emoji_icon: ':robot_face:'
+                 channel: <% $.archive_status_slack_channel %>
+                 message: 'Unfortunately an error occurred when trying to verify a randomly picked archive. See more details by running: `st2 execution get <% env().st2_execution_id %>`'
+               on-complete:
+                 - fail
+
+            ### NOTIFIER END ###

--- a/actions/workflows/archive_verify_specific.yaml
+++ b/actions/workflows/archive_verify_specific.yaml
@@ -9,7 +9,6 @@ workflows:
             - archive
             - description
             - host
-              #            - remove_previous_archive
         output:
             output_the_whole_workflow_context: <% $ %>
         task-defaults:

--- a/actions/workflows/archive_verify_specific.yaml
+++ b/actions/workflows/archive_verify_specific.yaml
@@ -1,0 +1,98 @@
+version: "2.0" # mistral version
+name: arteria-packs.archive_verify_specific
+description: Verify a specific runfolder archive that was uploaded to PDC
+
+workflows:
+    main:
+        type: direct
+        input:
+            - archive
+            - description
+            - host
+              #            - remove_previous_archive
+        output:
+            output_the_whole_workflow_context: <% $ %>
+        task-defaults:
+          on-error:
+            - notify_failure_on_slack
+
+        tasks:
+            ### GENERAL TASKS START ###
+            note_workflow_repo_version:
+              action: core.local
+              input:
+                cmd: git rev-parse HEAD
+                cwd: /opt/stackstorm/packs/arteria-packs/
+              on-success:
+                - get_config
+
+            get_config:
+              action: arteria-packs.get_pack_config
+              publish:
+                archive_verify_base_url: <% task(get_config).result.result.archive_verify_base_url %>
+                archive_status_slack_channel: <% task(get_config).result.result.archive_status_slack_channel %>
+                archive_db_base_url: <% task(get_config).result.result.archive_db_base_url %>
+              on-success:
+                - construct_poller_body
+
+            ### GENERAL TASKS END ###
+
+            ### TSM ARCHIVE VERIFY START ###
+
+            construct_poller_body: 
+              action: arteria-packs.parse_archive_verify_args
+              input:
+                archive: <% $.archive %>
+                description: <% $.description %>
+                host: <% $.host %>
+              publish:
+                verify_body: <% task(construct_poller_body).result.result %>
+              on-success:
+                - verify_archive_dir 
+
+            verify_archive_dir: 
+             action: arteria-packs.poll_status-archive
+             input:
+               url: <% $.archive_verify_base_url %>/verify
+               body: <% $.verify_body %>
+               verify_ssl_cert: True
+               irma_mode: False
+               timeout: 86400 # 24h timeout
+             publish: 
+               archive_path: <% task(verify_archive_dir).result.result.response_from_start.response.path %>
+             on-success:
+               - mark_verify_ok_in_db 
+
+            mark_verify_ok_in_db:
+                action: core.http
+                input:
+                  url: <% $.archive_db_base_url %>/verification
+                  body: '{ "description": "<% $.description %>", "host": "<% $.host %>", "path": "<% $.archive_path %>" }'
+                  method: "POST"
+                  timeout: 60
+                on-success: 
+                  - notify_success_on_slack
+               
+            notify_success_on_slack: 
+              action: arteria-packs.post_to_slack
+              input:
+                user: "I, Archivian"
+                emoji_icon: ":robot_face:"
+                channel: <% $.archive_status_slack_channel %>
+                message: "Successfully verified MD5 sums for archive `<% $.archive_path %>`. See details with `st2 execution get <% env().st2_execution_id %>`"
+
+            ### END TSM ARCHIVE VERIFY ###
+
+            ## NOTIFIER START ###
+
+            notify_failure_on_slack:
+               action: arteria-packs.post_to_slack
+               input:
+                 user: 'I, Archivian'
+                 emoji_icon: ':robot_face:'
+                 channel: <% $.archive_status_slack_channel %>
+                 message: 'Unfortunately an error occurred when trying to verify archive `<% $.archive %>` uploaded from `<% $.host %>`. You can see more details by running: `st2 execution get <% env().st2_execution_id %>`'
+               on-complete:
+                 - fail
+
+            ### NOTIFIER END ###

--- a/actions/workflows/archive_verify_specific.yaml
+++ b/actions/workflows/archive_verify_specific.yaml
@@ -38,7 +38,7 @@ workflows:
 
             ### TSM ARCHIVE VERIFY START ###
 
-            construct_poller_body: 
+            construct_poller_body:
               action: arteria-packs.parse_archive_verify_args
               input:
                 archive: <% $.archive %>
@@ -47,9 +47,9 @@ workflows:
               publish:
                 verify_body: <% task(construct_poller_body).result.result %>
               on-success:
-                - verify_archive_dir 
+                - verify_archive_dir
 
-            verify_archive_dir: 
+            verify_archive_dir:
              action: arteria-packs.poll_status-archive
              input:
                url: <% $.archive_verify_base_url %>/verify
@@ -57,10 +57,12 @@ workflows:
                verify_ssl_cert: True
                irma_mode: False
                timeout: 86400 # 24h timeout
-             publish: 
+             publish:
                archive_path: <% task(verify_archive_dir).result.result.response_from_start.response.path %>
+               archive_host: <% task(verify_archive_dir).result.result.response_from_start.response.host %>
+               archive_description: <% task(verify_archive_dir).result.result.response_from_start.response.description %>
              on-success:
-               - mark_verify_ok_in_db 
+               - mark_verify_ok_in_db
 
             mark_verify_ok_in_db:
                 action: core.http
@@ -69,16 +71,16 @@ workflows:
                   body: '{ "description": "<% $.description %>", "host": "<% $.host %>", "path": "<% $.archive_path %>" }'
                   method: "POST"
                   timeout: 60
-                on-success: 
+                on-success:
                   - notify_success_on_slack
-               
-            notify_success_on_slack: 
+
+            notify_success_on_slack:
               action: arteria-packs.post_to_slack
               input:
                 user: "I, Archivian"
                 emoji_icon: ":robot_face:"
                 channel: <% $.archive_status_slack_channel %>
-                message: "Successfully verified MD5 sums for archive `<% $.archive_path %>`. See details with `st2 execution get <% env().st2_execution_id %>`"
+                message: "Successfully verified MD5 sums for archive `<% $.archive_path %>` with description `<% $.archive_description %>` on `<% $.archive_host %>`. See details with `st2 execution get <% env().st2_execution_id %>`"
 
             ### END TSM ARCHIVE VERIFY ###
 

--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,6 @@ projman_connection_string: mssql+pymssql://<username>:<password>@<host>/<databas
 biotank_hosts: mm-xart002,mm-xart003
 biotank_user: arteria
 biotank_user_key: "/path/to/ssh/key"
-check_cert_slack_channel: "#bottest"
 
 remote_host: testuppmax
 remote_user: arteria
@@ -31,8 +30,10 @@ irma_remote_path: ./staging/
 irma_reports_remote_path: ./staging/reports/
 irma_checksum_base_url: https://irma1.uppmax.uu.se:4444/arteria_checksum_staging/api/1.0
 irma_siswrap_base_url: https://irma1.uppmax.uu.se:4444/arteria_siswrap_staging/api/1.0
-
+irma_archive_upload_base_url: https://irma1.uppmax.uu.se:4444/arteria_archive_staging/api/1.0
+archive_db_base_url: http://mm-xart002:10500/api/1.0/
 delivery_service_url: http://some-host.com:9999/
+archive_verify_base_url: http://mm-xart002:10400/api/1.0/
 
 irma_replace_expressions:
  - 's/UPPNEX_PROJECT: a2009002/UPPNEX_PROJECT: ngi2016001/'
@@ -43,6 +44,7 @@ send_mail_to: example.mail.address@send.errors.to
 runfolder_service_port: 10800
 bcl2fastq_service_port: 10900
 siswrap_service_port: 10700
+archive_upload_service_port: 10600
 
 # The service URL polled in the runfolder sensor:
 runfolder_svc_urls:
@@ -58,17 +60,11 @@ incoming_svc_urls:
 charon_api_token: dummy_token
 charon_base_url: http://charon.url
 slack_webhook_url: https://slack.webhook.url
-charon_status_report_slack_channel: "#bottest"
 
+charon_status_report_slack_channel: "#bottest"
+check_cert_slack_channel: "#bottest"
 delivery_workflow_status_slack_channel: '#bottest'
-# String of file paths to exclude from the compressed archive (egrep syntax)
-archive_excludes: "\"'^Config|^InterOp|^SampleSheet.csv|^Unaligned|^runParameters.xml|^RunInfo.xml\""
-# Which file entries we should not link to when creating the archive copy of the runfolder
-archive_exclude_links: "-e Data -e Thumbnail_Images"
-# Number of fastq files to expect when creating archive. If we find less files than this
-# then the action will fail.
-archive_fastq_threshold: 10
-archive_python_path: /opt/arteria/arteria-runfolder-env/bin/python
+archive_status_slack_channel: "#bottest"
 
 supr_api_user: apiuser
 supr_api_key: apikey

--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,16 @@ archive_db_base_url: http://mm-xart002:10500/api/1.0/
 delivery_service_url: http://some-host.com:9999/
 archive_verify_base_url: http://mm-xart002:10400/api/1.0/
 
+# Number of days we want to look back when picking an unverified but
+# uploaded archive. The exact time period will be adjusted by the safety
+# margin setting as well though.
+archive_db_verify_lookback_window: 7
+
+# Safety margin (days) when checking for an unverified but uploaded archive.
+# The margin is meant to ensure that we're not verifying something that PDC 
+# still keeps on disk - instead it should have been flushed to tape.
+archive_db_verify_safety_margin: 3
+
 irma_replace_expressions:
  - 's/UPPNEX_PROJECT: a2009002/UPPNEX_PROJECT: ngi2016001/'
  - 's/UPPNEX_QOS: seqver/#UPPNEX_QOS: seqver/'

--- a/config.yaml
+++ b/config.yaml
@@ -41,7 +41,7 @@ archive_verify_base_url: http://mm-xart002:10400/api/1.0/
 archive_db_verify_lookback_window: 7
 
 # Safety margin (days) when checking for an unverified but uploaded archive.
-# The margin is meant to ensure that we're not verifying something that PDC 
+# The margin is meant to ensure that we're not verifying something that PDC
 # still keeps on disk - instead it should have been flushed to tape.
 archive_db_verify_safety_margin: 3
 
@@ -55,6 +55,7 @@ runfolder_service_port: 10800
 bcl2fastq_service_port: 10900
 siswrap_service_port: 10700
 archive_upload_service_port: 10600
+archive_remove_service_port: 10300
 
 # The service URL polled in the runfolder sensor:
 runfolder_svc_urls:

--- a/rules/verify_random_archive.yaml
+++ b/rules/verify_random_archive.yaml
@@ -1,0 +1,18 @@
+---
+name: "arteria-packs.verify_random_archive"
+pack: "arteria-packs"
+description: "Verifies MD5sums for a randomly chosen, uploaded and unverified archive."
+enabled: true
+
+trigger:
+    type: "core.st2.CronTimer"
+    parameters:
+      timezone: "UTC"
+      day_of_week: "sun"
+      hour: 22
+      minute: 30
+      second: 0
+
+action:
+    ref: "arteria-packs.archive_verify_random"
+


### PR DESCRIPTION
**What problems does this PR solve?**
This PR adds two new Stackstorm workflows for doing verifications of archives that have previously been uploaded from a biotank: 

- `archive_verify_specific` downloads the specified archive to bioscreen, where it will verify the MD5 checksums, and if everything checks out mark it is as OK in the db (also running on bioscreen)
- `archive_verify_random` asks archive-db for a randomly chosen archive that has previously been uploaded within a certain time window, but has still not been verified. It will then call the previous workflow with this archive as input 

It then starts to sketch out some initial ideas about some removal workflows, but this is mostly a brain dump, as time doesn't permit more work on this from my part. I will elaborate more about this in a separate document later. 

From a bioinformatician's perspective there are some usability issues that are perhaps not optimal at the moment. All services uses the archive's `description` field in PDC TSM as their unique key/identifier (which `archive-upload` sets as an UUID4 token), but this means that sometimes the operator needs to map between this ID and the archive's directory name. Changes could probably be done to make this a bit better/easier. 

It also adds a rule for running `archive_verify_random` automatically once every weekend. 

**How has the changes been tested?**
The two removal workflows have been run manually in the staging environment. 

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
