### PR TITLE
If staged data is not returned "None" will be printed instead.

### DIFF
--- a/actions/arteria_delivery_service.py
+++ b/actions/arteria_delivery_service.py
@@ -128,7 +128,11 @@ class ArteriaDeliveryServiceHandler(object):
     @staticmethod
     def parse_stage_order_ids_from_response(response):
         projects_and_staging_order_ids = response['staging_order_ids']
-        staged_runfolders = list(map(lambda staged_path: staged_path.get('path',None), response['staged_data']))
+        staged_data = response.get('staged_data',None)
+        if staged_data is not None:
+            staged_runfolders = list(map(lambda staged_path: staged_path.get('path',None), staged_data))
+        else:
+            staged_runfolders = list()
 
         result = []
         for project, stage_order_id in projects_and_staging_order_ids.iteritems():

--- a/actions/arteria_delivery_service.py
+++ b/actions/arteria_delivery_service.py
@@ -129,7 +129,7 @@ class ArteriaDeliveryServiceHandler(object):
     def parse_stage_order_ids_from_response(response):
         projects_and_staging_order_ids = response['staging_order_ids']
         staged_data = response.get('staged_data',None)
-        if staged_data is not None:
+        if staged_data:
             staged_runfolders = list(map(lambda staged_path: staged_path.get('path',None), staged_data))
         else:
             staged_runfolders = list()

--- a/tests/test_action_delivery_service_stage_runfolders_for_project.py
+++ b/tests/test_action_delivery_service_stage_runfolders_for_project.py
@@ -14,6 +14,12 @@ class ArteriaDeliveryServiceTest(BaseActionTestCase):
         def __getitem__(self, key):
             return self.response_post[key]
 
+        def get(self, key, failobj=None):
+            if key not in self.response_post:
+                return failobj
+
+            return self.response_post[key]
+
     class MockGetResponse:
         def __init__(self, mock_response_get):
             self.response_get = mock_response_get


### PR DESCRIPTION
**What problems does this PR solve?**
An update in the latest version of arteria-packs makes it possible to list staged runfolders in the output from action delivery_service_stage_runfolders_for_project. Unfortunately, the delivery workflow for a single runfolder and for an analyzed project failed on the staging, action delivery_service_stage_runfolder and delivery_service_stage_project, because of this updated. This PR solves the issue by returning None if a list of staged data is missing in the staging response.  

**How has the changes been tested?**
Changes have only been tested in a Vagrant environment.

