### PR TITLE
Increased timeout limit for staging of projects

### DIFF
--- a/actions/workflows/delivery_project_workflow.yaml
+++ b/actions/workflows/delivery_project_workflow.yaml
@@ -79,6 +79,7 @@ workflows:
                  sleep_time: <% $.sleep_time %>
                  irma_api_key: <% $.irma_api_key %>
                  force_delivery: <% $.force_delivery %>
+                 timeout: 172800    
               publish:
                  projects_and_stage_ids: <% task(stage_project).result.result %>
               on-success:


### PR DESCRIPTION
**What problems does this PR solve?**
We've had some issues with delivering big projects due to staging step reaching timeout limit. This PR will give projects more time to perform staging. Another solution could be to add a timeout parameter to the workflow, let me know if you find that idea better. 
**How has the changes been tested?**
No.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
