### PR TITLE
Always create indexes, do index checking even if checkqc fails, and remove milou path

### DIFF
--- a/actions/archive_workflow.yaml
+++ b/actions/archive_workflow.yaml
@@ -1,0 +1,30 @@
+---
+name: archive_workflow
+description: >
+  Archives a runfolder to PDC with TSM
+enabled: true
+runner_type: mistral-v2
+entry_point: workflows/archive_workflow.yaml
+pack: arteria-packs
+parameters:
+  context:
+    default: {}
+    immutable: true
+    type: object
+  workflow:
+    default: arteria-packs.archive_workflow
+    immutable: true
+    type: string
+  host:
+    description: 'Host where runfolder is located'
+    required: true
+    type: string
+  runfolder:
+    description: 'Path to runfolder to archive'
+    required: true
+    type: string
+  remove_previous_archive: 
+    description: 'Set to true to remove previous archive'
+    required: true
+    type: boolean
+    default: false

--- a/actions/compress_archive_package.yaml
+++ b/actions/compress_archive_package.yaml
@@ -1,0 +1,33 @@
+---
+    name: 'compress_archive_package'
+    runner_type: 'run-local'
+    description: 'Creates a compressed archive of a subset of files inside a runfolder, ready to be sent to PDC with TSM.'
+    enabled: true
+    entry_point: ''
+    parameters:
+        timeout:
+        # Use a default timeout of 24 hour. "No timout" is fixed in a new version
+        # https://github.com/StackStorm/st2/issues/1654
+            default: 86400
+        runfolder:
+            type: 'string'
+            description: 'Path to runfolder to archive'
+            required: true
+            position: 1
+        exclude:
+            type: 'string'
+            description: 'egrep pattern for files to exclude from archive'
+            required: true
+            position: 2
+        host:
+            type: 'string'
+            description: 'Host where runfolder is located'
+            required: true
+            position: 3
+        cmd:
+            immutable: true 
+            default: 'ssh -v {{host}} "bash -s" < /opt/stackstorm/packs/arteria-packs/actions/lib/compress_archive_package.sh {{ runfolder }} {{ exclude }}'
+        connect_timeout:
+            type: 'integer'
+            description: 'SSH connect timeout in seconds'
+            default: 86400 # 24 h

--- a/actions/create_archive_dir.yaml
+++ b/actions/create_archive_dir.yaml
@@ -1,0 +1,43 @@
+---
+    name: 'create_archive_dir'
+    runner_type: 'run-local'
+    description: 'Creates a copy of the runfolder, consisting of symlinks, for archiving purposes.'
+    enabled: true
+    entry_point: ''
+    parameters:
+        timeout:
+            default: 86400
+        runfolder:
+            type: 'string'
+            description: 'Path to runfolder to archive'
+            required: true
+        fastq_threshold:
+            type: 'integer'
+            description: 'Action will fail if less than this number of fastq files are found'
+            required: true
+        remove_previous: 
+            type: 'boolean'
+            description: 'Set to true if we want to remove an already existing archive directory'
+            required: true
+            default: false
+        host:
+            type: 'string'
+            description: 'Host where runfolder is located'
+            required: true
+        python_path:
+            type: 'string'
+            description: 'Path to the Python 2.7 binary to use'
+            required: true
+            default: '/opt/arteria/arteria-runfolder-env/bin/python'
+        exclude_links: 
+            type: 'string'
+            description: 'Argument to script for which links we should not create'
+            required: false
+            default: '-e Data -e Thumbnail_Images'
+        cmd:
+            immutable: true 
+            default: 'ssh -v {{host}} "{{python_path}} -u - {{exclude_links}} -t {{fastq_threshold}} --remove={{remove_previous}} {{runfolder}}" < /opt/stackstorm/packs/arteria-packs/actions/lib/create_archive_dir.py'
+        connect_timeout:
+            type: 'integer'
+            description: 'SSH connect timeout in seconds'
+            default: 86400 # 24 h

--- a/actions/lib/compress_archive_package.sh
+++ b/actions/lib/compress_archive_package.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Simple script that should be executed on a biotank when we want to compress a
+# runfolder to be archived to PDC via TSM. The runfolder to archive is expected
+# to be a folder full of symlinks pointing to real source folder. 
+
+set -e
+set -o pipefail 
+
+# The full path to the runfolder that we want to archive.
+RUNFOLDER=$1
+
+RUNFOLDER_NAME=$(basename ${RUNFOLDER})
+
+# The exclude pattern is for everything we do not want to pack, and is configurable 
+# upstreams. It should hopefully look something like the following. 
+# EXCLUDE="^Config|^InterOp|^SampleSheet.csv|^Unaligned|^runParameters.xml|^RunInfo.xml"
+# Escaping various quotes can be messy though. 
+EXCLUDE=$2
+
+cd ${RUNFOLDER}
+
+# If the normal archive workflow is re-run then the tar ball shouldn't exist anymore because
+# either the linked directory structory will be re-created from scratch, or the workflow
+# should have aborted at an earlier stage because the archive dir already exists. 
+# Still, just in case, abort if it is found. 
+if [ -f ./${RUNFOLDER_NAME}.tar.gz ]; then
+  echo "Gziped archive file ${RUNFOLDER_NAME}.tar.gz already exists. Manual intervention required."
+  exit 1
+fi
+
+# Create list of root links to include in the compressed part of the archive.
+# Should have a couple of file patterns excluded from the config. 
+# 
+# NB: As this works now the excluded files from the tar ball must be a link
+# in the root folder. If we want to be able to exclude files deeper in the 
+# directory tree then we need to redo this step, as well as the tar and 
+# removal step. 
+ls -A | egrep -v ${EXCLUDE} > ./.links-to-pack
+
+# Pack everything together. Compressing is perhaps not strictly necessary, but it 
+# will save some space for primarily the log files. We want to derefence symlinks, 
+# as normal procedure is to archive a runfolder full with symlinks to the files 
+# that should be uploaded.
+tar -h -T ./.links-to-pack -c -z -f ./${RUNFOLDER_NAME}.tar.gz 
+
+# Remove all symlinks that we include in the tar ball 
+for link in `cat ${RUNFOLDER}/.links-to-pack`; do 
+    rm ${RUNFOLDER}/${link}
+done
+

--- a/actions/lib/create_archive_dir.py
+++ b/actions/lib/create_archive_dir.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+import os, sys, shutil, argparse
+
+def verify_src(srcdir, threshold = None):
+  if not os.path.exists(srcdir) or not os.path.isdir(srcdir):
+    print("Runfolder {} is not a directory and/or doesn't exist. Aborting.".format(srcdir))
+    sys.exit(1)
+
+  unaligned_link = os.path.join(srcdir, "Unaligned")
+  unaligned_dir = os.path.abspath(unaligned_link)
+
+  if not os.path.exists(unaligned_link) or not os.path.islink(unaligned_link): 
+    print("Expected link {} doesn't seem to exist or is broken. Aborting.".format(unaligned_link))
+    sys.exit(1)
+  elif not os.path.exists(unaligned_dir) or not os.path.isdir(unaligned_dir): 
+    print("Expected directory {} doesn't seem to exist. Aborting.".format(unaligned_dir))
+    sys.exit(1) 
+  else:
+    counter = 0
+
+    for root, dirs, files in os.walk(unaligned_dir):
+      for file in files: 
+        if file.lower().endswith(".fastq.gz"):
+          counter = counter + 1
+  
+    if threshold and counter < threshold: 
+        print("We found only {} files that seems to be FASTQ files. Expecting at least {} files. Looks suspicious; aborting.".format(counter, threshold))
+        sys.exit(1)
+
+def verify_dest(destdir, remove=False): 
+  if os.path.exists(destdir):
+    if remove: 
+      print("Archive directory {} already exists. Operator requested to remove it.".format(destdir))
+      shutil.rmtree(destdir)
+    else: 
+      print("Archive directory {} already exists. Aborting.".format(destdir))
+      sys.exit(1)
+
+def create_dest(srcdir, destdir, exclude = None): 
+  os.makedirs(destdir)
+
+  for entry in os.listdir(srcdir):
+    if not entry in exclude: 
+      os.symlink(os.path.join(srcdir, entry), os.path.join(destdir, entry))
+ 
+  print("Archive directory {} created successfully.".format(destdir))
+
+def str2bool(val): 
+    return val.lower() in ("yes", "true", "1")  
+
+if __name__ == "__main__": 
+  parser = argparse.ArgumentParser(description="Takes a runfolder's path as an argument and creates a copy of it with symlinks\n"\
+                                               "as its content, suitable for archiving to PDC. Created copy will be placed in\n"\
+                                               "the same root path as the runfolder, with suffix '_archive'. If the destination\n"\
+                                               "copy already exists then the script will abort.\n\n"\
+                                               "The script will also scan for expected subdir/link 'Unaligned' in the runfolder\n"\
+                                               "to archive. If it doesn't exist then it will abort. Inside 'Unaligned' it will\n"\
+                                               "look for fastq.gz files. If the number of files found are less than the\n"\
+                                               "specified threshold value then the script will abort.",
+                                   formatter_class=argparse.RawTextHelpFormatter)
+  parser.add_argument("runfolder", help="path to the runfolder to archive")
+  parser.add_argument("-e", "--exclude", action='append', help="filename to exclude from archive (argument can be repeated)")
+  parser.add_argument("-t", "--threshold", default=10, type=int, help="will abort if less than this many FASTQ files are found (default 10)") 
+  parser.add_argument("-r", "--remove", default='false', type=str2bool, help="if set to true then script will remove any already existing archive directories (default false)") 
+  
+  args = parser.parse_args()
+  srcdir = os.path.abspath(args.runfolder)
+  exclude = args.exclude
+  threshold = args.threshold
+  remove = args.remove
+
+  destdir = srcdir + "_archive" 
+  verify_src(srcdir, threshold)
+  verify_dest(destdir, remove)
+  create_dest(srcdir, destdir, exclude)

--- a/actions/parse_bcl2fastq_args.yaml
+++ b/actions/parse_bcl2fastq_args.yaml
@@ -34,3 +34,8 @@ parameters:
     default: ""
     type: string
     description: "Any additional arguments to bcl2fastq can be fed here. Note that quoutes (\") are needed around arguments for the to parse properly. E.g. \"--my-first-arg 1 --my-second-arg 2\" "
+
+  create_indexes:
+    default: True
+    type: boolean
+    description: "Create fastq files for indexes."

--- a/actions/parse_bcl2fastq_args.yaml
+++ b/actions/parse_bcl2fastq_args.yaml
@@ -36,6 +36,6 @@ parameters:
     description: "Any additional arguments to bcl2fastq can be fed here. Note that quoutes (\") are needed around arguments for the to parse properly. E.g. \"--my-first-arg 1 --my-second-arg 2\" "
 
   create_indexes:
-    default: True
-    type: boolean
+    default: "True"
+    type: string
     description: "Create fastq files for indexes."

--- a/actions/run_checkqc.py
+++ b/actions/run_checkqc.py
@@ -17,14 +17,26 @@ class RunCheckQC(Action):
             self.logger.error("An error was encountered when "
                               "querying url: {0},  {1}".format(url, err))
             raise err
+        except ValueError as err:
+            self.logger.error("An error was encountered when "
+                              "querying url: {0},  {1}".format(url, err))
+            raise err
 
     def run(self, url, ignore_result, verify_ssl_cert):
-        response = self.query(url, verify_ssl_cert).json()
-        exit_status = response["exit_status"]
-        if (ignore_result and exit_status != 0):
-            self.logger.warning("Ignoring the failed result because of override flag.")
-            return True, response
-        elif exit_status == 0:
-            return True, response
-        else:
-            return False, response
+        try:
+            response = self.query(url, verify_ssl_cert).json()
+            exit_status = response["exit_status"]
+            if ignore_result:
+                self.logger.warning("Ignoring the failed result because of override flag.")
+                return True, response
+            elif exit_status == 0:
+                return True, response
+            else:
+                self.logger.error("Exit status was not 0!")
+                return False, response
+        except ValueError:
+            if ignore_result:
+                self.logger.warning("Ignoring the failed result because of override flag.")
+                return True, response
+            else:
+                return False, response

--- a/actions/run_checkqc.py
+++ b/actions/run_checkqc.py
@@ -34,9 +34,9 @@ class RunCheckQC(Action):
             else:
                 self.logger.error("Exit status was not 0!")
                 return False, response
-        except ValueError:
+        except ValueError as e:
             if ignore_result:
                 self.logger.warning("Ignoring the failed result because of override flag.")
-                return True
+                return True, "Ignored this error: {0}".format(e)
             else:
-                return False
+                return False, "Found this error: {0}".format(e)

--- a/actions/run_checkqc.py
+++ b/actions/run_checkqc.py
@@ -37,6 +37,6 @@ class RunCheckQC(Action):
         except ValueError:
             if ignore_result:
                 self.logger.warning("Ignoring the failed result because of override flag.")
-                return True, response
+                return True
             else:
-                return False, response
+                return False

--- a/actions/workflows/archive_workflow.yaml
+++ b/actions/workflows/archive_workflow.yaml
@@ -1,0 +1,76 @@
+version: "2.0" # mistral version
+name: arteria-packs.archive_workflow
+description: Archives a runfolder to PDC with TSM
+
+workflows:
+    main:
+        type: direct
+        input:
+            - runfolder
+            - host
+            - remove_previous_archive
+        output:
+            output_the_whole_workflow_context: <% $ %>
+
+        tasks:
+            ### GENERAL TASKS START ###
+            note_workflow_repo_version:
+              action: core.local
+              input:
+                cmd: git rev-parse HEAD
+                cwd: /opt/stackstorm/packs/arteria-packs/
+              on-success:
+                - get_config
+
+            get_config:
+              action: arteria-packs.get_pack_config
+              publish:
+                archive_excludes: <% task(get_config).result.result.archive_excludes %>
+                archive_fastq_threshold: <% task(get_config).result.result.archive_fastq_threshold %>
+                archive_python_path: <% task(get_config).result.result.archive_python_path %>
+                archive_exclude_links: <% task(get_config).result.result.archive_exclude_links %>
+              on-success:
+                - create_archive_dir
+
+            ### GENERAL TASKS END ###
+
+            ### TRANSFER FILES START ###
+            create_archive_dir: 
+              action: arteria-packs.create_archive_dir
+              input: 
+                host: <% $.host %>
+                runfolder: <% $.runfolder %>
+                fastq_threshold: <% $.archive_fastq_threshold %> # number of fastq files to expect; if less then the action will fail
+                python_path: <% $.archive_python_path %>
+                exclude_links: <% $.archive_exclude_links %>
+                remove_previous: <% $.remove_previous_archive %>
+              on-success: 
+                - compress_tsm_archive     
+            
+            # Will compress some of the files in the archive. Script will fail if gziped archive already exists. 
+            compress_tsm_archive:
+               action: arteria-packs.compress_archive_package
+               input:
+                 host: <% $.host %>
+                 runfolder: <% $.runfolder %>_archive
+                 exclude: <% $.archive_excludes %>
+               on-success:
+                 - generate_checksums
+
+            generate_checksums:
+                action: core.local
+                input:
+                  cmd: ssh <% $.host %> "cd <% $.runfolder %>_archive && find -L . -type f ! -path './checksums_prior_to_pdc.md5' -exec md5sum {} + > checksums_prior_to_pdc.md5"
+                  timeout: 86400 # 24 h timeout
+                on-success:
+                  - tsm_archive_to_pdc
+
+            # We need to filter out all files excluded from the upload because otherwise TSM
+            # will fill up the Stackstorm/Mongo buffer too much. 
+            tsm_archive_to_pdc:
+                action: core.local
+                input:
+                  cmd: ssh <% $.host %> "dsmc archive <% $.runfolder %>_archive/ -subdir=yes -description=`uuidgen`"
+                  timeout: 604800 # 1w worst-case timeout
+
+            ### TRANSFER FILES END ###

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -37,9 +37,6 @@ workflows:
             get_config:
               action: arteria-packs.get_pack_config
               publish:
-                hermes_base_url: <% task(get_config).result.result.hermes_base_url %>
-                hermes_user: <% task(get_config).result.result.hermes_user %>
-                hermes_token: <% task(get_config).result.result.hermes_token %>
                 remote_host: <% task(get_config).result.result.remote_host %>
                 remote_user: <% task(get_config).result.result.remote_user%>
                 remote_destination: <% task(get_config).result.result.remote_destination %>
@@ -219,22 +216,11 @@ workflows:
                 runfolder_name: "<% $.runfolder_name %>"
                 private_key: <% $.summary_host_key %>
               on-success:
-                - check_hosts_to_rsync_to
+                - make_irma_samplesheet_changes
 
-            check_hosts_to_rsync_to:
-               action: core.http
-               input:
-                    url: <% $.hermes_base_url %>/<% $.flowcell_name %>/flowcell/analysishostinfo
-                    headers:
-                      USER: <% $.hermes_user %>
-                      X-XSRF-TOKEN: <% $.hermes_token %>
-               on-success:
-                    - rsync_to_milou: <% 'milou-b.uppmax.uu.se' in task(check_hosts_to_rsync_to).result.body.remote_hosts %>
-                    - make_irma_samplesheet_changes: <% 'irma.uppmax.uu.se' in task(check_hosts_to_rsync_to).result.body.remote_hosts %>
-
-             # Irma requies specific values in the sisyphus.yml to work.
-             # This is a hack to replace those specific values for runs
-             # which are to be synced to irma.
+            # Irma requies specific values in the sisyphus.yml to work.
+            # This is a hack to replace those specific values for runs
+            # which are to be synced to irma.
             make_irma_samplesheet_changes:
                with-items: expression in <% $.irma_replace_expressions %>
                action: core.local
@@ -242,33 +228,6 @@ workflows:
                  cmd: ssh <% $.host %> sed -i -e \'<% $.expression %>\' <% $.runfolder %>/sisyphus.yml
                on-success:
                  - rsync_to_irma
-
-            rsync_to_milou:
-                action: arteria-packs.sync_workflow
-                input:
-                    runfolder: <% $.runfolder %>
-                    runfolder_name: <% $.runfolder_name %>
-                    source_host: <% $.host %>
-                    source_user: "arteria"
-                    destination_host: <% $.remote_host %>
-                    destination_user: <% $.remote_user %>
-                    destination_path: <% $.remote_destination %>
-                    rsync_include_file: /etc/arteria/misc/hiseq.rsync
-                    md5_output_file: "checksums.md5"
-                on-success:
-                    - milou_check_md5sums
-
-            milou_check_md5sums:
-                action: core.remote
-                input:
-                    hosts: <% $.remote_host %>
-                    username: <% $.remote_user %>
-                    cwd: <% $.remote_destination %>
-                    cmd: md5sum -c  <% $.remote_destination %>/<% $.runfolder_name %>/MD5/checksums.md5
-                    timeout: 86400 # 24 h timeout
-                    private_key: <% $.remote_host_key %>
-                on-success:
-                    - milou_start_aeacus_stats
 
             rsync_to_irma:
                 action: arteria-packs.sync_workflow
@@ -324,36 +283,6 @@ workflows:
                 - mark_as_finished: <% $.skip_archiving = true %>
 
             ### END AEACUS REPORT STEPS ###
-            # TODO Need to add starting the ngi pipeline on irma
-
-            milou_start_aeacus_stats:
-                action: core.remote
-                input:
-                    hosts: <% $.remote_host %>
-                    username: <% $.remote_user %>
-                    cwd: <% $.remote_destination %>/<% $.runfolder_name %>
-                    cmd: <% $.remote_sisyphus_location %>/aeacus-stats.pl -runfolder <% $.remote_destination %>/<% $.runfolder_name %>
-                    private_key: <% $.remote_host_key %>
-                    env:
-                        PERL5LIB: /proj/a2009002/perl/lib/perl5/
-                on-success:
-                    - milou_start_aeacus_report
-
-            milou_start_aeacus_report:
-                action: core.remote
-                input:
-                    hosts: <% $.remote_host %>
-                    username: <% $.remote_user %>
-                    cwd: <% $.remote_destination %>/<% $.runfolder_name %>
-                    cmd: <% $.remote_sisyphus_location %>/aeacus-reports.pl -runfolder <% $.remote_destination %>/<% $.runfolder_name %>
-                    private_key: <% $.remote_host_key %>
-                    env:
-                        PERL5LIB: /proj/a2009002/perl/lib/perl5/
-                on-success:
-                    - upload_runfolder_to_pdc: <% $.skip_archiving = false %>
-                    - notify_finished: <% $.skip_archiving = true %>
-                    - mark_as_finished: <% $.skip_archiving = true %>
-            ## START AEACUS REPORT STEPS END ###
 
             ## START NGI_PIPELINE IF NECESSARY ##
             # TODO Make sure to setup new URL for ngi_pipeline

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -287,15 +287,28 @@ workflows:
             ## END START NGI_PIPELINE ##
 
             ## START TSM ARCHIVE TO PDC ##
+
             upload_runfolder_to_pdc:
-                action: arteria-packs.archive_upload
+                action: arteria-packs.archive_workflow
                 input:
-                    runfolder: <% $.runfolder_name %>
+                    runfolder: <% $.runfolder %>
                     host: <% $.host %>
                     remove_previous_archive: <% $.remove_previous_archive_dir %>
                 on-success:
                   - notify_finished
                   - mark_as_finished
+
+# TODO Add this back to switch to the new archiving workflow that we have
+#      disabled for now. /JD 2018-04-25
+#            upload_runfolder_to_pdc:
+#                action: arteria-packs.archive_upload
+#                input:
+#                    runfolder: <% $.runfolder_name %>
+#                    host: <% $.host %>
+#                    remove_previous_archive: <% $.remove_previous_archive_dir %>
+#                on-success:
+#                  - notify_finished
+#                  - mark_as_finished
             ## END TSM ARCHIVE TO PDC ##
 
             ## NOTIFIER START ###

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -130,6 +130,7 @@ workflows:
                     tiles: "<% $.tiles %>"
                     use_base_mask: "<% $.use_base_mask %>"
                     additional_arguments: "<% $.bcl2fastq_additional_arguments %>"
+                    create_indexes: "True"
                 publish:
                     bcl2fastq_body: <% task(construct_bcl2fastq_body).result.result %>
                 on-success:

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -130,7 +130,7 @@ workflows:
                     tiles: "<% $.tiles %>"
                     use_base_mask: "<% $.use_base_mask %>"
                     additional_arguments: "<% $.bcl2fastq_additional_arguments %>"
-                    create_indexes: "True"
+                    create_indexes: True
                 publish:
                     bcl2fastq_body: <% task(construct_bcl2fastq_body).result.result %>
                 on-success:

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -159,7 +159,9 @@ workflows:
               input:
                 url: "http://<% $.host %>:<% $.checkqc_service_port %>/qc/<% $.runfolder_name %>"
                 ignore_result: <% $.ignore_qc_result %>
-              on-success:
+              publish:
+                run_check_qc_exit_flag: <% task(run_checkqc).result.exit_code %>
+              on-complete:
                 - copy_sisyphus_config
 
             copy_sisyphus_config:
@@ -180,7 +182,8 @@ workflows:
                       runfolder: <% $.runfolder_name %>
                     ignore_result: <% $.ignore_qc_result %>
                 on-success:
-                    - get_year
+                    - get_year: <% $.run_check_qc_exit_flag = 0 %>
+                    - oh_shit_error: <% $.run_check_qc_exit_flag != 0 %>
             ### CHECK INDICES END###
             ### TRANSFER FILES TO UPPMAX START ###
             get_year:

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -182,8 +182,8 @@ workflows:
                       runfolder: <% $.runfolder_name %>
                     ignore_result: <% $.ignore_qc_result %>
                 on-success:
-                    - get_year: <% task(run_checkqc).status = "succeeded"  %>
-                    - oh_shit_error: <% task(run_checkqc).status != "succeeded" %>
+                    - get_year: <% task(run_checkqc).state = "SUCCESS"  %>
+                    - oh_shit_error: <% task(run_checkqc).state != "SUCCESS" %>
             ### CHECK INDICES END###
             ### TRANSFER FILES TO UPPMAX START ###
             get_year:

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -130,7 +130,7 @@ workflows:
                     tiles: "<% $.tiles %>"
                     use_base_mask: "<% $.use_base_mask %>"
                     additional_arguments: "<% $.bcl2fastq_additional_arguments %>"
-                    create_indexes: True
+                    create_indexes: "True"
                 publish:
                     bcl2fastq_body: <% task(construct_bcl2fastq_body).result.result %>
                 on-success:

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -182,8 +182,8 @@ workflows:
                       runfolder: <% $.runfolder_name %>
                     ignore_result: <% $.ignore_qc_result %>
                 on-success:
-                    - get_year: <% task(run_checkqc).state = "SUCCESS"  %>
-                    - oh_shit_error: <% task(run_checkqc).state != "SUCCESS" %>
+                    - get_year: <% task(run_checkqc).state = 'SUCCESS'  %>
+                    - oh_shit_error: <% task(run_checkqc).state != 'SUCCESS' %>
             ### CHECK INDICES END###
             ### TRANSFER FILES TO UPPMAX START ###
             get_year:

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -221,18 +221,7 @@ workflows:
                 runfolder_name: "<% $.runfolder_name %>"
                 private_key: <% $.summary_host_key %>
               on-success:
-                - make_irma_samplesheet_changes
-
-            # Irma requies specific values in the sisyphus.yml to work.
-            # This is a hack to replace those specific values for runs
-            # which are to be synced to irma.
-            make_irma_samplesheet_changes:
-               with-items: expression in <% $.irma_replace_expressions %>
-               action: core.local
-               input:
-                 cmd: ssh <% $.host %> sed -i -e \'<% $.expression %>\' <% $.runfolder %>/sisyphus.yml
-               on-success:
-                 - rsync_to_irma
+                - rsync_to_irma
 
             rsync_to_irma:
                 action: arteria-packs.sync_workflow

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -182,8 +182,8 @@ workflows:
                       runfolder: <% $.runfolder_name %>
                     ignore_result: <% $.ignore_qc_result %>
                 on-success:
-                    - get_year: <% $.run_check_qc_exit_flag = 0 %>
-                    - oh_shit_error: <% $.run_check_qc_exit_flag != 0 %>
+                    - get_year: <% task(run_checkqc).status = "succeeded"  %>
+                    - oh_shit_error: <% task(run_checkqc).status != "succeeded" %>
             ### CHECK INDICES END###
             ### TRANSFER FILES TO UPPMAX START ###
             get_year:

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -159,9 +159,9 @@ workflows:
               input:
                 url: "http://<% $.host %>:<% $.checkqc_service_port %>/qc/<% $.runfolder_name %>"
                 ignore_result: <% $.ignore_qc_result %>
-              publish:
-                run_check_qc_exit_flag: <% task(run_checkqc).result.exit_code %>
-              on-complete:
+              on-success:
+                - copy_sisyphus_config
+              on-error:
                 - copy_sisyphus_config
 
             copy_sisyphus_config:
@@ -183,7 +183,8 @@ workflows:
                     ignore_result: <% $.ignore_qc_result %>
                 on-success:
                     - get_year: <% task(run_checkqc).state = 'SUCCESS'  %>
-                    - oh_shit_error: <% task(run_checkqc).state != 'SUCCESS' %>
+                    - oh_shit_error: <% task(run_checkqc).state = 'ERROR' %>
+                    - mark_as_failed: <% task(run_checkqc).state = 'ERROR' %>
             ### CHECK INDICES END###
             ### TRANSFER FILES TO UPPMAX START ###
             get_year:

--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,5 @@
 ---
 
-hermes_base_url: http://130.238.178.239:9000/api/0.1
-hermes_user: dummy_user
-hermes_token: my_token
-
 summary_host: testuppmax
 summary_user: arteria
 summary_host_key: /path/to/ssh/key

--- a/scripts/create_dot_graph.py
+++ b/scripts/create_dot_graph.py
@@ -5,7 +5,7 @@ import argparse
 from graphviz import Digraph
 
 
-def add_edges(dot, look_up_key, task_name, task):
+def add_edges(dot, look_up_key, task_name, task, label=None):
     on_success_key = look_up_key
     if on_success_key not in task:
         pass
@@ -19,18 +19,24 @@ def add_edges(dot, look_up_key, task_name, task):
                 for key in elem:
                     dot.edge(task_name, key, label=elem[key])
             else:
-                dot.edge(task_name, elem)
+                dot.edge(task_name, elem, label=label)
 
 
 def add_success_edges(dot, task_name, task):
-    add_edges(dot, "on-success", task_name, task)
+    add_edges(dot, "on-success", task_name, task, label="on-success")
 
 
 def add_error_edges(dot, task_name, task):
-    add_edges(dot, "on-error", task_name, task)
+    add_edges(dot, "on-error", task_name, task, label="on-failure")
+
+
+def add_on_complete_edges(dot, task_name, task):
+    add_edges(dot, "on-complete", task_name, task, label="on-complete")
 
 
 def main(argv):
+
+    print("Generating graph...")
 
     parser = argparse.ArgumentParser(description='Create a dot representation of the give mistral workflow file')
     parser.add_argument('--file', required=True, help='Path to workflow file')
@@ -50,6 +56,7 @@ def main(argv):
         dot.node(key)
         add_success_edges(dot, key, task)
         add_error_edges(dot, key, task)
+        add_on_complete_edges(dot, key, task)
 
     dot.render(args.output)
 


### PR DESCRIPTION
**What problems does this PR solve?**
This PR does a few different things:
 - it removes all references to milou, since that system is no longer in use
 - it makes sure that the indexes are still checked, even if checkqc fails first
- it makes bcl2fastq generate fastq files for the index reads (as required for chromium runs) for all our runs

**How has the changes been tested?**
This has been tested (though not fully validated on mm-xart001 and mm-xart002).

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
