### PR TITLE
make slack poster raise exception on failure

### DIFF
--- a/actions/lib/slack.py
+++ b/actions/lib/slack.py
@@ -1,9 +1,7 @@
 
 import requests
-
-import datetime
-
 from st2actions.runners.pythonrunner import Action
+
 
 class SlackNotifier():
 
@@ -20,6 +18,7 @@ class SlackNotifier():
 
     def _post_to_slack(self, json_message):
         response = self.session.post(self.base_url, json=json_message)
+        response.raise_for_status()
         return response.status_code
 
     def post_message(self, message):
@@ -52,13 +51,7 @@ class SlackPoster(Action):
                                  user=user,
                                  icon_emoji=kwargs.get('emoji_icon'))
         try:
-            status = notifier.post_message(message)
-            if status == 200:
-                return True
-            else:
-                return False
+            notifier.post_message(message)
         except Exception as e:
             self.logger.error("Got error when trying to post to Slack: {}".format(e))
-            return False
-
-
+            raise

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -1,0 +1,24 @@
+import mock
+import requests
+from st2tests.base import BaseActionTestCase
+
+from lib.slack import SlackPoster, SlackNotifier
+
+
+class TestSlackPoster(BaseActionTestCase):
+    action_cls = SlackPoster
+
+    @mock.patch("lib.slack.SlackNotifier", autospec=True)
+    def test_successful_post(self, notifier_mock):
+        action = self.get_action_instance()
+        action.config["slack_webhook_url"] = "this-is-the-webhook-url"
+        self.assertIsNone(action.run("channel", "user", "message"))
+
+    @mock.patch("lib.slack.SlackNotifier", autospec=True)
+    def test_unsuccessful_post(self, notifier_mock):
+        action = self.get_action_instance()
+        action.config["slack_webhook_url"] = "this-is-the-webhook-url"
+        notifier = notifier_mock.return_value
+        notifier.post_message.side_effect = requests.exceptions.HTTPError("a mock HTTPError")
+        with self.assertRaises(requests.exceptions.HTTPError):
+            action.run("channel", "user", "message")


### PR DESCRIPTION
**What problems does this PR solve?**

The python script that posts to Slack would return True or False, which Stackstorm would always interpret as a successful action. This PR ensures that the script raises an exception if posting fails, which should make Stackstorm report properly.

**How has the changes been tested?**

Unit tests have been added and run in a Vagrant environment.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
