### PR TITLE
Change irma node for rsync

### DIFF
--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -230,7 +230,7 @@ workflows:
                     runfolder_name: <% $.runfolder_name %>
                     source_host: <% $.host %>
                     source_user: "arteria"
-                    destination_host: "irma2.uppmax.uu.se"
+                    destination_host: "irma4.uppmax.uu.se"
                     destination_user: "funk_901"
                     destination_path: <% $.irma_remote_path %>
                     rsync_include_file: /etc/arteria/misc/hiseq.rsync


### PR DESCRIPTION
**What problems does this PR solve?**
Irma2 is currently not working correctly, because of this we are going to use Irma4 instead. I would prefer it to be a variable configurable through the config, but since we want this fix out as soon as possible I am postponing that to a later time. 

**How has the changes been tested?**
No. 

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
