### PR TITLE
optionally specify path to specific archive to verify

### DIFF
--- a/actions/archive_verify_specific.yaml
+++ b/actions/archive_verify_specific.yaml
@@ -27,3 +27,7 @@ parameters:
     description: 'Unique description used when uploading archive to PDC'
     required: true
     type: string
+  path:
+    description: 'Full path to the archive on PDC. If not specified, the path will be guessed from host and archive'
+    required: false
+    type: string

--- a/actions/workflows/archive_verify_random.yaml
+++ b/actions/workflows/archive_verify_random.yaml
@@ -46,6 +46,7 @@ workflows:
                 archive_name: <% task(get_random_archive_to_verify).result.body.archive.archive %>
                 archive_host: <% task(get_random_archive_to_verify).result.body.archive.host %>
                 archive_description: <% task(get_random_archive_to_verify).result.body.archive.description %>
+                archive_path: <% task(get_random_archive_to_verify).result.body.archive.path %>
               on-success:
                 - verify_archive
 
@@ -55,6 +56,7 @@ workflows:
                 archive: <% $.archive_name %>
                 host: <% $.archive_host %>
                 description: <% $.archive_description %>
+                path: <% $.archive_path %>
 
             ### END TSM ARCHIVE VERIFY ###
 

--- a/actions/workflows/archive_verify_specific.yaml
+++ b/actions/workflows/archive_verify_specific.yaml
@@ -9,6 +9,7 @@ workflows:
             - archive
             - description
             - host
+            - path
         output:
             output_the_whole_workflow_context: <% $ %>
         task-defaults:
@@ -44,6 +45,7 @@ workflows:
                 archive: <% $.archive %>
                 description: <% $.description %>
                 host: <% $.host %>
+                path: <% $.path %>
               publish:
                 verify_body: <% task(construct_poller_body).result.result %>
               on-success:


### PR DESCRIPTION
**What problems does this PR solve?**

The archive-db stores the PDC path to the archive and returns it when an entry is requested from the database. The workflow doesn't use this path though but favors constructing it from the host and archive names. Typically, the full name of the host (e.g. biotank5.sequencing) does not match the hostname used in the path (e.g. biotank5), which causes the archive-verify action to fail. 

This PR addresses this by taking the returned path from the db and pass it to the archive-verify service.

See also [PR to service](https://github.com/Molmed/snpseq-archive-verify/pull/2)

**How has the changes been tested?**
Not tested yet, will be done on staging.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data