### PR TITLE
enable slack notifier to use a proxy

### DIFF
--- a/actions/lib/slack.py
+++ b/actions/lib/slack.py
@@ -5,8 +5,10 @@ from st2actions.runners.pythonrunner import Action
 
 class SlackNotifier():
 
-    def __init__(self, base_url, channel, user, icon_emoji=None):
+    def __init__(self, base_url, channel, user, icon_emoji=None, proxies=None):
         self.session = requests.Session()
+        if proxies:
+            self.session.proxies = proxies
         self.headers = {'content-type': 'application/json'}
         self.base_url = base_url
         self.channel = channel
@@ -46,10 +48,14 @@ class SlackNotifier():
 class SlackPoster(Action):
 
     def run(self, channel, user, message, **kwargs):
+        proxies = None
+        if "slack_proxy_url" in self.config and self.config["slack_proxy_url"] != "":
+            proxies = {'http': self.config["slack_proxy_url"], 'https' : self.config["slack_proxy_url"] }
         notifier = SlackNotifier(base_url=self.config["slack_webhook_url"],
                                  channel=channel,
                                  user=user,
-                                 icon_emoji=kwargs.get('emoji_icon'))
+                                 icon_emoji=kwargs.get('emoji_icon'),
+                                 proxies=proxies)
         try:
             notifier.post_message(message)
         except Exception as e:

--- a/config.yaml
+++ b/config.yaml
@@ -68,6 +68,8 @@ incoming_svc_urls:
 charon_api_token: dummy_token
 charon_base_url: http://charon.url
 slack_webhook_url: https://slack.webhook.url
+# proxy to use when posting to slack
+slack_proxy_url:
 
 charon_status_report_slack_channel: "#bottest"
 check_cert_slack_channel: "#bottest"


### PR DESCRIPTION
**What problems does this PR solve?**
This PR allows configuring the `post_to_slack` action to use a proxy when connecting to the API hook.

**How has the changes been tested?**
Tested on the `testarteria-master` vagrant machine with a proxy running on `testgwy`

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
