### PR TITLE
from stackstorm 2.1 onward dashes are no longer allowed in packs' names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-snpseq-packs
+snpseq_packs
 -------------
 
 StackStorm pack to setup automation workflow taking data from the sequencer to delivery on the remote host...
 
 Development and testing
 -----------------------
-To make development and testing of snpseq-packs simpler, we provide a Vagrant environment (this requires that VirtualBox is installed on your system).
+To make development and testing of snpseq_packs simpler, we provide a Vagrant environment (this requires that VirtualBox is installed on your system).
 
 ```
 # Get it up and running
@@ -20,7 +20,7 @@ cd /vagrant
 # Now you can start developing on the packs
 
 # Note that all the scripts run below this point assume that your current
-# working directory is the packs directory i.e. /snpseq-packs in
+# working directory is the packs directory i.e. /snpseq_packs in
 # the vagrant environment
 
 # Prepare the test environment environment (this only needs to be
@@ -31,10 +31,10 @@ cd /vagrant
 # venv in the working directory
 
 # Run the tests
-./utils/run_tests.sh /opt/stackstorm/packs/snpseq-packs
+./utils/run_tests.sh /opt/stackstorm/packs/snpseq_packs
 
 # To test registering all pack components run
-./utils/st2-check-register-pack-resources utils/st2.tests.conf /opt/stackstorm/packs/snpseq-packs
+./utils/st2-check-register-pack-resources utils/st2.tests.conf /opt/stackstorm/packs/snpseq_packs
 
 ```
 
@@ -50,7 +50,7 @@ Example of starting a workflow
 
 Now you should be good to go. Here's an example of how to run a action:
 
-     st2 run snpseq-packs.ngi_uu_workflow runfolder=/data/testarteria1/150605_M00485_0183_000000000-ABGT6_testbio14 host=testarteria1
+     st2 run snpseq_packs.ngi_uu_workflow runfolder=/data/testarteria1/150605_M00485_0183_000000000-ABGT6_testbio14 host=testarteria1
      
 To see the result of a run - you can first list the executions:
 
@@ -67,7 +67,7 @@ Each execution will get it's own unique id when run by StackStorm. However it ca
 in other ways. Such as being able to see all executions for a particular runfolder for example. You can achieve this by
  using  the `--trace-tag` argument when staring a job, e.g:
  
-    st2 run snpseq-packs.ngi_uu_workflow \
+    st2 run snpseq_packs.ngi_uu_workflow \
         runfolder=/data/testarteria1/150605_M00485_0183_000000000-ABGT6_testbio14 \
         host=testarteria1 \
         --trace-tag 150605_M00485_0183_000000000-ABGT6_testbio14

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,7 +31,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       inline: "curl -sSL https://stackstorm.com/packages/install.sh | bash -s -- --user=#{arteriauser} --password=#{arteriapasswd} --version=#{st2version}"
 
     arteria.vm.provision "shell", 
-      inline: "ln -s /vagrant /opt/stackstorm/packs/snpseq-packs"
+      inline: "ln -s /vagrant /opt/stackstorm/packs/snpseq_packs"
 
   end
 

--- a/actions/archive_missing_files.yaml
+++ b/actions/archive_missing_files.yaml
@@ -5,14 +5,14 @@ description: >
 enabled: true
 runner_type: mistral-v2
 entry_point: workflows/archive_missing_files.yaml
-pack: snpseq-packs
+pack: snpseq_packs
 parameters:
   context:
     default: {}
     immutable: true
     type: object
   workflow:
-    default: snpseq-packs.archive_missing_files
+    default: snpseq_packs.archive_missing_files
     immutable: true
     type: string
   host:

--- a/actions/archive_upload.yaml
+++ b/actions/archive_upload.yaml
@@ -5,14 +5,14 @@ description: >
 enabled: true
 runner_type: mistral-v2
 entry_point: workflows/archive_upload.yaml
-pack: snpseq-packs
+pack: snpseq_packs
 parameters:
   context:
     default: {}
     immutable: true
     type: object
   workflow:
-    default: snpseq-packs.archive_upload
+    default: snpseq_packs.archive_upload
     immutable: true
     type: string
   host:

--- a/actions/archive_verify_random.yaml
+++ b/actions/archive_verify_random.yaml
@@ -5,13 +5,13 @@ description: >
 enabled: true
 runner_type: mistral-v2
 entry_point: workflows/archive_verify_random.yaml
-pack: snpseq-packs
+pack: snpseq_packs
 parameters:
   context:
     default: {}
     immutable: true
     type: object
   workflow:
-    default: snpseq-packs.archive_verify_random
+    default: snpseq_packs.archive_verify_random
     immutable: true
     type: string

--- a/actions/archive_verify_specific.yaml
+++ b/actions/archive_verify_specific.yaml
@@ -5,14 +5,14 @@ description: >
 enabled: true
 runner_type: mistral-v2
 entry_point: workflows/archive_verify_specific.yaml
-pack: snpseq-packs
+pack: snpseq_packs
 parameters:
   context:
     default: {}
     immutable: true
     type: object
   workflow:
-    default: snpseq-packs.archive_verify_specific
+    default: snpseq_packs.archive_verify_specific
     immutable: true
     type: string
   host:

--- a/actions/archive_workflow.yaml
+++ b/actions/archive_workflow.yaml
@@ -5,14 +5,14 @@ description: >
 enabled: true
 runner_type: mistral-v2
 entry_point: workflows/archive_workflow.yaml
-pack: snpseq-packs
+pack: snpseq_packs
 parameters:
   context:
     default: {}
     immutable: true
     type: object
   workflow:
-    default: snpseq-packs.archive_workflow
+    default: snpseq_packs.archive_workflow
     immutable: true
     type: string
   host:

--- a/actions/charon_project_status.yaml
+++ b/actions/charon_project_status.yaml
@@ -4,4 +4,4 @@ description: Check the general Charon project status and post it to slack
 enabled: true
 runner_type: run-python
 entry_point: lib/charon_project_status.py
-pack: snpseq-packs
+pack: snpseq_packs

--- a/actions/charon_set_delivery_status.yaml
+++ b/actions/charon_set_delivery_status.yaml
@@ -4,7 +4,7 @@ description: Set the delivery status of a set of project/samples in Charon.
 enabled: true
 runner_type: run-python
 entry_point: lib/charon.py
-pack: snpseq-packs
+pack: snpseq_packs
 parameters:
     action:
       type: string

--- a/actions/check_irma_certs.yaml
+++ b/actions/check_irma_certs.yaml
@@ -4,14 +4,14 @@ description: Warn if Irma SSH certs are soon to expire
 enabled: true
 runner_type: mistral-v2
 entry_point: workflows/check_irma_certs.yaml
-pack: snpseq-packs
+pack: snpseq_packs
 parameters:
   context:
     default: {}
     immutable: true
     type: object
   workflow:
-    default: snpseq-packs.check_irma_certs
+    default: snpseq_packs.check_irma_certs
     immutable: true
     type: string
   days:

--- a/actions/compress_archive_package.yaml
+++ b/actions/compress_archive_package.yaml
@@ -26,7 +26,7 @@
             position: 3
         cmd:
             immutable: true 
-            default: 'ssh -v {{host}} "bash -s" < /opt/stackstorm/packs/snpseq-packs/actions/lib/compress_archive_package.sh {{ runfolder }} {{ exclude }}'
+            default: 'ssh -v {{host}} "bash -s" < /opt/stackstorm/packs/snpseq_packs/actions/lib/compress_archive_package.sh {{ runfolder }} {{ exclude }}'
         connect_timeout:
             type: 'integer'
             description: 'SSH connect timeout in seconds'

--- a/actions/create_archive_dir.yaml
+++ b/actions/create_archive_dir.yaml
@@ -36,7 +36,7 @@
             default: '-e Data -e Thumbnail_Images'
         cmd:
             immutable: true 
-            default: 'ssh -v {{host}} "{{python_path}} -u - {{exclude_links}} -t {{fastq_threshold}} --remove={{remove_previous}} {{runfolder}}" < /opt/stackstorm/packs/snpseq-packs/actions/lib/create_archive_dir.py'
+            default: 'ssh -v {{host}} "{{python_path}} -u - {{exclude_links}} -t {{fastq_threshold}} --remove={{remove_previous}} {{runfolder}}" < /opt/stackstorm/packs/snpseq_packs/actions/lib/create_archive_dir.py'
         connect_timeout:
             type: 'integer'
             description: 'SSH connect timeout in seconds'

--- a/actions/create_sis_style_checksums.yaml
+++ b/actions/create_sis_style_checksums.yaml
@@ -41,7 +41,7 @@
             position: 6
         cmd:
             immutable: true
-            default: 'ssh -v {{host}} "bash -s" < /opt/stackstorm/packs/snpseq-packs/actions/lib/create_sis_style_checksums.sh {{ source }} {{ include_file }} {{ output_file }}'
+            default: 'ssh -v {{host}} "bash -s" < /opt/stackstorm/packs/snpseq_packs/actions/lib/create_sis_style_checksums.sh {{ source }} {{ include_file }} {{ output_file }}'
         connect_timeout:
             type: 'integer'
             description: 'SSH connect timeout in seconds'

--- a/actions/delivery_project_workflow.yaml
+++ b/actions/delivery_project_workflow.yaml
@@ -4,14 +4,14 @@ description: Deliver a project (i.e. a directory placed in the directory defined
 enabled: true
 runner_type: mistral-v2
 entry_point: workflows/delivery_project_workflow.yaml
-pack: snpseq-packs
+pack: snpseq_packs
 parameters:
   context:
     default: {}
     immutable: true
     type: object
   workflow:
-    default: snpseq-packs.delivery_project_workflow
+    default: snpseq_packs.delivery_project_workflow
     immutable: true
     type: string
   project_name:

--- a/actions/delivery_runfolder_workflow.yaml
+++ b/actions/delivery_runfolder_workflow.yaml
@@ -4,14 +4,14 @@ description: Deliver a runfolder
 enabled: true
 runner_type: mistral-v2
 entry_point: workflows/delivery_runfolder_workflow.yaml
-pack: snpseq-packs
+pack: snpseq_packs
 parameters:
   context:
     default: {}
     immutable: true
     type: object
   workflow:
-    default: snpseq-packs.delivery_runfolder_workflow
+    default: snpseq_packs.delivery_runfolder_workflow
     immutable: true
     type: string
   runfolder_name:

--- a/actions/delivery_runfolders_for_project_workflow.yaml
+++ b/actions/delivery_runfolders_for_project_workflow.yaml
@@ -4,14 +4,14 @@ description: Deliver a project (i.e. a directory placed in the directory defined
 enabled: true
 runner_type: mistral-v2
 entry_point: workflows/delivery_runfolders_for_project_workflow.yaml
-pack: snpseq-packs
+pack: snpseq_packs
 parameters:
   context:
     default: {}
     immutable: true
     type: object
   workflow:
-    default: snpseq-packs.delivery_runfolers_for_workflow
+    default: snpseq_packs.delivery_runfolers_for_workflow
     immutable: true
     type: string
   project_name:

--- a/actions/download_samplesheet_mount.yaml
+++ b/actions/download_samplesheet_mount.yaml
@@ -4,7 +4,7 @@ runner_type: "python-script"
 description: "Reads samplesheets from a mount on the Stackstorm server as fallback to the Clarity LIMS, keyed on flowcell id"
 enabled: true
 entry_point: "download_samplesheet_mount.py"
-pack: "snpseq-packs"
+pack: "snpseq_packs"
 parameters:
   flowcell_name:
     type: "string"

--- a/actions/gather_ngi_pipeline_reports.yaml
+++ b/actions/gather_ngi_pipeline_reports.yaml
@@ -4,13 +4,13 @@ description: Downloads the ngi pipeline reports to the summary host
 enabled: true
 runner_type: mistral-v2
 entry_point: workflows/gather_ngi_pipeline_reports.yaml
-pack: snpseq-packs
+pack: snpseq_packs
 parameters:
   context:
     default: {}
     immutable: true
     type: object
   workflow:
-    default: snpseq-packs.gather_ngi_pipeline_reports
+    default: snpseq_packs.gather_ngi_pipeline_reports
     immutable: true
     type: string

--- a/actions/gather_project_reports.yaml
+++ b/actions/gather_project_reports.yaml
@@ -4,14 +4,14 @@ description: Sync project reports from Irma to the summary host
 enabled: true
 runner_type: mistral-v2
 entry_point: workflows/gather_project_reports.yaml
-pack: snpseq-packs
+pack: snpseq_packs
 parameters:
   context:
     default: {}
     immutable: true
     type: object
   workflow:
-    default: snpseq-packs.gather_project_reports
+    default: snpseq_packs.gather_project_reports
     immutable: true
     type: string
   year:

--- a/actions/ngi_uu_workflow.yaml
+++ b/actions/ngi_uu_workflow.yaml
@@ -7,14 +7,14 @@ description: >
 enabled: true
 runner_type: mistral-v2
 entry_point: workflows/ngi_uu_workflow.yaml
-pack: snpseq-packs
+pack: snpseq_packs
 parameters:
   context:
     default: {}
     immutable: true
     type: object
   workflow:
-    default: snpseq-packs.ngi_uu_workflow
+    default: snpseq_packs.ngi_uu_workflow
     immutable: true
     type: string
   host:

--- a/actions/post_to_slack.yaml
+++ b/actions/post_to_slack.yaml
@@ -4,7 +4,7 @@ description: Will post the given message to slack on the specified channel.
 enabled: true
 runner_type: run-python
 entry_point: lib/slack.py
-pack: snpseq-packs
+pack: snpseq_packs
 parameters:
   channel:
     type: 'string'

--- a/actions/sync_workflow.yaml
+++ b/actions/sync_workflow.yaml
@@ -5,14 +5,14 @@ description: >
 enabled: true
 runner_type: mistral-v2
 entry_point: workflows/sync_workflow.yaml
-pack: snpseq-packs
+pack: snpseq_packs
 parameters:
   context:
     default: {}
     immutable: true
     type: object
   workflow:
-    default: snpseq-packs.sync_workflow
+    default: snpseq_packs.sync_workflow
     immutable: true
     type: string
   runfolder:

--- a/actions/workflows/archive_missing_files.yaml
+++ b/actions/workflows/archive_missing_files.yaml
@@ -1,5 +1,5 @@
 version: "2.0" # mistral version
-name: snpseq-packs.archive_missing_files
+name: snpseq_packs.archive_missing_files
 description: Reuploads missing files from an archive to PDC with TSM
 
 workflows:
@@ -20,12 +20,12 @@ workflows:
               action: core.local
               input:
                 cmd: git rev-parse HEAD
-                cwd: /opt/stackstorm/packs/snpseq-packs/
+                cwd: /opt/stackstorm/packs/snpseq_packs/
               on-success:
                 - get_config
 
             get_config:
-              action: snpseq-packs.get_pack_config
+              action: snpseq_packs.get_pack_config
               publish:
                 archive_upload_port: <% task(get_config).result.result.archive_upload_service_port %>
                 archive_status_slack_channel: <% task(get_config).result.result.archive_status_slack_channel %>
@@ -39,7 +39,7 @@ workflows:
             ### TSM ARCHIVE TO PDC START ###
 
             upload_missing_files_to_pdc:
-                action: snpseq-packs.poll_status-archive
+                action: snpseq_packs.poll_status-archive
                 input:
                   url: http://<% $.host %>:<% $.archive_upload_port %>/api/1.0/reupload/<% $.runfolder %>_archive
                   verify_ssl_cert: True
@@ -74,7 +74,7 @@ workflows:
                     body: "Finished archiving missing files for <% $.runfolder %>_archive on <% $.host %>."
 
             notify_failure_on_slack:
-               action: snpseq-packs.post_to_slack
+               action: snpseq_packs.post_to_slack
                input:
                  user: 'I, Archivian'
                  emoji_icon: ':robot_face:'

--- a/actions/workflows/archive_upload.yaml
+++ b/actions/workflows/archive_upload.yaml
@@ -1,5 +1,5 @@
 version: "2.0" # mistral version
-name: snpseq-packs.archive_upload
+name: snpseq_packs.archive_upload
 description: Archives a runfolder to PDC with TSM
 
 workflows:
@@ -21,12 +21,12 @@ workflows:
               action: core.local
               input:
                 cmd: git rev-parse HEAD
-                cwd: /opt/stackstorm/packs/snpseq-packs/
+                cwd: /opt/stackstorm/packs/snpseq_packs/
               on-success:
                 - get_config
 
             get_config:
-              action: snpseq-packs.get_pack_config
+              action: snpseq_packs.get_pack_config
               publish:
                 archive_upload_port: <% task(get_config).result.result.archive_upload_service_port %>
                 archive_status_slack_channel: <% task(get_config).result.result.archive_status_slack_channel %>
@@ -58,7 +58,7 @@ workflows:
                  - generate_checksums
 
             generate_checksums:
-                action: snpseq-packs.poll_status-archive
+                action: snpseq_packs.poll_status-archive
                 input:
                   url: http://<% $.host %>:<% $.archive_upload_port %>/api/1.0/gen_checksums/<% $.runfolder %>_archive
                   verify_ssl_cert: True
@@ -68,7 +68,7 @@ workflows:
                   - upload_archive
 
             upload_archive:
-                action: snpseq-packs.poll_status-archive
+                action: snpseq_packs.poll_status-archive
                 input:
                   url: http://<% $.host %>:<% $.archive_upload_port %>/api/1.0/upload/<% $.runfolder %>_archive
                   verify_ssl_cert: True
@@ -94,7 +94,7 @@ workflows:
             ## NOTIFIER START ###
 
             notify_failure_on_slack:
-               action: snpseq-packs.post_to_slack
+               action: snpseq_packs.post_to_slack
                input:
                  user: 'I, Archivian'
                  emoji_icon: ':robot_face:'

--- a/actions/workflows/archive_verify_random.yaml
+++ b/actions/workflows/archive_verify_random.yaml
@@ -1,5 +1,5 @@
 version: "2.0" # mistral version
-name: snpseq-packs.archive_verify_random
+name: snpseq_packs.archive_verify_random
 description: Verify a randomly picked runfolder archive that was uploaded to PDC. Supposed to be run each week. Picks a runfolder that has not been verified previously, and was uploaded within the interval [1 week ago, yesterday].
 
 workflows:
@@ -17,12 +17,12 @@ workflows:
               action: core.local
               input:
                 cmd: git rev-parse HEAD
-                cwd: /opt/stackstorm/packs/snpseq-packs/
+                cwd: /opt/stackstorm/packs/snpseq_packs/
               on-success:
                 - get_config
 
             get_config:
-              action: snpseq-packs.get_pack_config
+              action: snpseq_packs.get_pack_config
               publish:
                 archive_status_slack_channel: <% task(get_config).result.result.archive_status_slack_channel %>
                 archive_db_base_url: <% task(get_config).result.result.archive_db_base_url %>
@@ -51,7 +51,7 @@ workflows:
                 - verify_archive
 
             verify_archive:
-              action: snpseq-packs.archive_verify_specific
+              action: snpseq_packs.archive_verify_specific
               input:
                 archive: <% $.archive_name %>
                 host: <% $.archive_host %>
@@ -63,7 +63,7 @@ workflows:
             ## NOTIFIER START ###
 
             notify_failure_on_slack:
-               action: snpseq-packs.post_to_slack
+               action: snpseq_packs.post_to_slack
                input:
                  user: 'I, Archivian'
                  emoji_icon: ':robot_face:'

--- a/actions/workflows/archive_verify_specific.yaml
+++ b/actions/workflows/archive_verify_specific.yaml
@@ -1,5 +1,5 @@
 version: "2.0" # mistral version
-name: snpseq-packs.archive_verify_specific
+name: snpseq_packs.archive_verify_specific
 description: Verify a specific runfolder archive that was uploaded to PDC
 
 workflows:
@@ -22,12 +22,12 @@ workflows:
               action: core.local
               input:
                 cmd: git rev-parse HEAD
-                cwd: /opt/stackstorm/packs/snpseq-packs/
+                cwd: /opt/stackstorm/packs/snpseq_packs/
               on-success:
                 - get_config
 
             get_config:
-              action: snpseq-packs.get_pack_config
+              action: snpseq_packs.get_pack_config
               publish:
                 archive_verify_base_url: <% task(get_config).result.result.archive_verify_base_url %>
                 archive_status_slack_channel: <% task(get_config).result.result.archive_status_slack_channel %>
@@ -40,7 +40,7 @@ workflows:
             ### TSM ARCHIVE VERIFY START ###
 
             construct_poller_body:
-              action: snpseq-packs.parse_archive_verify_args
+              action: snpseq_packs.parse_archive_verify_args
               input:
                 archive: <% $.archive %>
                 description: <% $.description %>
@@ -52,7 +52,7 @@ workflows:
                 - verify_archive_dir
 
             verify_archive_dir:
-              action: snpseq-packs.poll_status-archive
+              action: snpseq_packs.poll_status-archive
               input:
                 url: <% $.archive_verify_base_url %>/verify
                 body: <% $.verify_body %>
@@ -75,7 +75,7 @@ workflows:
                 - notify_success_on_slack
 
             notify_success_on_slack:
-              action: snpseq-packs.post_to_slack
+              action: snpseq_packs.post_to_slack
               input:
                 user: "I, Archivian"
                 emoji_icon: ":robot_face:"
@@ -87,7 +87,7 @@ workflows:
             ## NOTIFIER START ###
 
             notify_failure_on_slack:
-              action: snpseq-packs.post_to_slack
+              action: snpseq_packs.post_to_slack
               input:
                 user: 'I, Archivian'
                 emoji_icon: ':robot_face:'

--- a/actions/workflows/archive_workflow.yaml
+++ b/actions/workflows/archive_workflow.yaml
@@ -1,5 +1,5 @@
 version: "2.0" # mistral version
-name: snpseq-packs.archive_workflow
+name: snpseq_packs.archive_workflow
 description: Archives a runfolder to PDC with TSM
 
 workflows:
@@ -18,12 +18,12 @@ workflows:
               action: core.local
               input:
                 cmd: git rev-parse HEAD
-                cwd: /opt/stackstorm/packs/snpseq-packs/
+                cwd: /opt/stackstorm/packs/snpseq_packs/
               on-success:
                 - get_config
 
             get_config:
-              action: snpseq-packs.get_pack_config
+              action: snpseq_packs.get_pack_config
               publish:
                 archive_excludes: <% task(get_config).result.result.archive_excludes %>
                 archive_fastq_threshold: <% task(get_config).result.result.archive_fastq_threshold %>
@@ -36,7 +36,7 @@ workflows:
 
             ### TRANSFER FILES START ###
             create_archive_dir: 
-              action: snpseq-packs.create_archive_dir
+              action: snpseq_packs.create_archive_dir
               input: 
                 host: <% $.host %>
                 runfolder: <% $.runfolder %>
@@ -49,7 +49,7 @@ workflows:
             
             # Will compress some of the files in the archive. Script will fail if gziped archive already exists. 
             compress_tsm_archive:
-               action: snpseq-packs.compress_archive_package
+               action: snpseq_packs.compress_archive_package
                input:
                  host: <% $.host %>
                  runfolder: <% $.runfolder %>_archive

--- a/actions/workflows/check_irma_certs.yaml
+++ b/actions/workflows/check_irma_certs.yaml
@@ -1,5 +1,5 @@
 version: "2.0" # mistral version
-name: snpseq-packs.check_irma_certs
+name: snpseq_packs.check_irma_certs
 description: Logins to all hosts daily and warns if the SSH certs expires within two weeks.
 
 workflows:
@@ -16,12 +16,12 @@ workflows:
               action: core.local
               input:
                 cmd: git rev-parse HEAD
-                cwd: /opt/stackstorm/packs/snpseq-packs/
+                cwd: /opt/stackstorm/packs/snpseq_packs/
               on-success:
                   - get_config
 
             get_config:
-              action: snpseq-packs.get_pack_config
+              action: snpseq_packs.get_pack_config
               publish:
                 biotank_hosts: <% task(get_config).result.result.biotank_hosts %>
                 biotank_user: <% task(get_config).result.result.biotank_user %>
@@ -51,7 +51,7 @@ workflows:
                 private_key: <% $.biotank_user_key %>
 
             post_failed_message_to_slack:
-              action: snpseq-packs.post_to_slack
+              action: snpseq_packs.post_to_slack
               input:
                 user: 'Cert Police'
                 emoji_icon: ':robot_face:'

--- a/actions/workflows/delivery_project_workflow.yaml
+++ b/actions/workflows/delivery_project_workflow.yaml
@@ -1,5 +1,5 @@
 version: "2.0" # mistral version
-name: snpseq-packs.delivery_project_workflow
+name: snpseq_packs.delivery_project_workflow
 description: Deliver data from a project (i.e. a directory with the project name) to a SNIC delivery project
 
 workflows:
@@ -21,12 +21,12 @@ workflows:
               action: core.local
               input:
                 cmd: git rev-parse HEAD
-                cwd: /opt/stackstorm/packs/snpseq-packs/
+                cwd: /opt/stackstorm/packs/snpseq_packs/
               on-success:
                   - get_config
 
             get_config:
-              action: snpseq-packs.get_pack_config
+              action: snpseq_packs.get_pack_config
               publish:
                 supr_api_user: <% task(get_config).result.result.supr_api_user %>
                 supr_api_key: <% task(get_config).result.result.supr_api_key %>
@@ -38,7 +38,7 @@ workflows:
                  - post_start_message_to_slack
 
             post_start_message_to_slack:
-              action: snpseq-packs.post_to_slack
+              action: snpseq_packs.post_to_slack
               input:
                 user: 'Bot D Liver'
                 emoji_icon: ':robot_face:'
@@ -48,7 +48,7 @@ workflows:
                  - get_pi_emails
 
             get_pi_emails:
-              action: snpseq-packs.read_projects_email_file
+              action: snpseq_packs.read_projects_email_file
               input:
                 file_path: <% $.projects_pi_email_file %>
                 projects:
@@ -60,7 +60,7 @@ workflows:
                 - get_pi_ids
 
             get_pi_ids:
-              action: snpseq-packs.get_pi_id_for_email_from_supr
+              action: snpseq_packs.get_pi_id_for_email_from_supr
               input:
                 project_to_email_sensitive_dict: <% $.projects_to_emails_sensitive %>
                 api_user: <% $.supr_api_user %>
@@ -72,7 +72,7 @@ workflows:
                 - stage_project
 
             stage_project:
-              action: snpseq-packs.delivery_service_stage_project
+              action: snpseq_packs.delivery_service_stage_project
               input:
                  delivery_base_api_url: <% $.delivery_service_url %>
                  project_name: <% $.project_name %>
@@ -86,7 +86,7 @@ workflows:
                 - create_delivery_projects
 
             create_delivery_projects:
-              action: snpseq-packs.create_delivery_project_in_super
+              action: snpseq_packs.create_delivery_project_in_super
               input:
                 project_names_and_ids: <% $.pi_supr_ids %>
                 staging_info: <% $.projects_and_stage_ids %>
@@ -101,7 +101,7 @@ workflows:
 
             # TODO Remember to pass correct md5sum files for the project.
             deliver_project:
-              action: snpseq-packs.delivery_service_deliver
+              action: snpseq_packs.delivery_service_deliver
               with-items: ngi_project_name in <% $.projects_and_stage_ids.keys() %>
               input:
                 ngi_project_name: <% $.ngi_project_name %>
@@ -116,7 +116,7 @@ workflows:
                 - check_delivery_status
 
             check_delivery_status:
-              action: snpseq-packs.delivery_service_delivery_status
+              action: snpseq_packs.delivery_service_delivery_status
               with-items:
                 - id in <% $.delivery_projects_and_ids.delivery_id %>
                 - ngi_project_name in <% $.delivery_projects_and_ids.project_name %>
@@ -133,7 +133,7 @@ workflows:
                 - get_best_practice_samples: <% $.skip_mover = true and $.set_delivery_status_in_charon = true %>
 
             check_ngi_ready_status:
-              action: snpseq-packs.check_ngi_ready_in_supr
+              action: snpseq_packs.check_ngi_ready_in_supr
               with-items:
                 - project in <% $.delivery_projects.keys() %>
               input:
@@ -157,7 +157,7 @@ workflows:
                 - set_to_delivered_in_charon
 
             set_to_delivered_in_charon:
-              action: snpseq-packs.charon_set_delivery_status
+              action: snpseq_packs.charon_set_delivery_status
               input:
                project: <% $.project_name %>
                delivery_status: DELIVERED
@@ -166,7 +166,7 @@ workflows:
                 - post_finish_message_to_slack
 
             post_finish_message_to_slack:
-              action: snpseq-packs.post_to_slack
+              action: snpseq_packs.post_to_slack
               input:
                 user: 'Bot D Liver'
                 emoji_icon: ':robot_face:'
@@ -174,7 +174,7 @@ workflows:
                 message: 'I just finished a delivery for `<% $.project_name %>`. You can see the details by running: `st2 execution get <% env().st2_execution_id %>`'
 
             post_failed_message_to_slack:
-              action: snpseq-packs.post_to_slack
+              action: snpseq_packs.post_to_slack
               input:
                 user: 'Bot D Liver'
                 emoji_icon: ':robot_face:'

--- a/actions/workflows/delivery_runfolder_workflow.yaml
+++ b/actions/workflows/delivery_runfolder_workflow.yaml
@@ -1,5 +1,5 @@
 version: "2.0" # mistral version
-name: snpseq-packs.delivery_runfolder_workflow
+name: snpseq_packs.delivery_runfolder_workflow
 description: Deliver data from a runfolder to a SNIC delivery project
 
 workflows:
@@ -21,12 +21,12 @@ workflows:
               action: core.local
               input:
                 cmd: git rev-parse HEAD
-                cwd: /opt/stackstorm/packs/snpseq-packs/
+                cwd: /opt/stackstorm/packs/snpseq_packs/
               on-success:
                   - get_config
 
             get_config:
-              action: snpseq-packs.get_pack_config
+              action: snpseq_packs.get_pack_config
               publish:
                 supr_api_user: <% task(get_config).result.result.supr_api_user %>
                 supr_api_key: <% task(get_config).result.result.supr_api_key %>
@@ -38,7 +38,7 @@ workflows:
                  - post_start_message_to_slack
 
             post_start_message_to_slack:
-              action: snpseq-packs.post_to_slack
+              action: snpseq_packs.post_to_slack
               input:
                 user: 'Bot D Liver'
                 emoji_icon: ':robot_face:'
@@ -60,7 +60,7 @@ workflows:
                 - get_pi_emails
 
             get_pi_emails:
-              action: snpseq-packs.read_projects_email_file
+              action: snpseq_packs.read_projects_email_file
               input:
                 file_path: <% $.projects_pi_email_file %>
                 projects:
@@ -72,7 +72,7 @@ workflows:
                 - get_pi_ids
 
             get_pi_ids:
-              action: snpseq-packs.get_pi_id_for_email_from_supr
+              action: snpseq_packs.get_pi_id_for_email_from_supr
               input:
                 project_to_email_sensitive_dict: <% $.projects_to_emails_sensitive %>
                 api_user: <% $.supr_api_user %>
@@ -84,7 +84,7 @@ workflows:
                 - stage_runfolder
 
             stage_runfolder:
-              action: snpseq-packs.delivery_service_stage_runfolder
+              action: snpseq_packs.delivery_service_stage_runfolder
               input:
                  delivery_base_api_url: <% $.delivery_service_url %>
                  runfolder_name: <% $.runfolder_name %>
@@ -100,7 +100,7 @@ workflows:
                 - create_delivery_projects
 
             create_delivery_projects:
-              action: snpseq-packs.create_delivery_project_in_super
+              action: snpseq_packs.create_delivery_project_in_super
               input:
                 project_names_and_ids: <% $.pi_supr_ids %>
                 staging_info: <% $.projects_and_stage_ids %>
@@ -115,7 +115,7 @@ workflows:
 
             # TODO Remember to pass correct md5sum files for the project.
             deliver_runfolder:
-              action: snpseq-packs.delivery_service_deliver
+              action: snpseq_packs.delivery_service_deliver
               with-items: ngi_project_name in <% $.projects_and_stage_ids.keys() %>
               input:
                 ngi_project_name: <% $.ngi_project_name %>
@@ -130,7 +130,7 @@ workflows:
                 - check_delivery_status
 
             check_delivery_status:
-              action: snpseq-packs.delivery_service_delivery_status
+              action: snpseq_packs.delivery_service_delivery_status
               with-items:
                 - id in <% $.delivery_projects_and_ids.delivery_id %>
                 - ngi_project_name in <% $.delivery_projects_and_ids.project_name %>
@@ -146,7 +146,7 @@ workflows:
                 - post_finish_message_to_slack: <% $.skip_mover = true %>
 
             check_ngi_ready_status:
-              action: snpseq-packs.check_ngi_ready_in_supr
+              action: snpseq_packs.check_ngi_ready_in_supr
               with-items:
                 - project in <% $.delivery_projects.keys() %>
               input:
@@ -158,7 +158,7 @@ workflows:
                 - post_finish_message_to_slack
 
             post_finish_message_to_slack:
-              action: snpseq-packs.post_to_slack
+              action: snpseq_packs.post_to_slack
               input:
                 user: 'Bot D Liver'
                 emoji_icon: ':robot_face:'
@@ -166,7 +166,7 @@ workflows:
                 message: 'I just finished a delivery for `<% $.runfolder_name %>`. You can see the details by running: `st2 execution get <% env().st2_execution_id %>`'
 
             post_failed_message_to_slack:
-              action: snpseq-packs.post_to_slack
+              action: snpseq_packs.post_to_slack
               input:
                 user: 'Bot D Liver'
                 emoji_icon: ':robot_face:'

--- a/actions/workflows/delivery_runfolders_for_project_workflow.yaml
+++ b/actions/workflows/delivery_runfolders_for_project_workflow.yaml
@@ -1,5 +1,5 @@
 version: "2.0" # mistral version
-name: snpseq-packs.delivery_runfolders_for_project_workflow
+name: snpseq_packs.delivery_runfolders_for_project_workflow
 description: Deliver runfolders for a specific project to a SNIC delivery project
 
 workflows:
@@ -21,12 +21,12 @@ workflows:
               action: core.local
               input:
                 cmd: git rev-parse HEAD
-                cwd: /opt/stackstorm/packs/snpseq-packs/
+                cwd: /opt/stackstorm/packs/snpseq_packs/
               on-success:
                   - get_config
 
             get_config:
-              action: snpseq-packs.get_pack_config
+              action: snpseq_packs.get_pack_config
               publish:
                 supr_api_user: <% task(get_config).result.result.supr_api_user %>
                 supr_api_key: <% task(get_config).result.result.supr_api_key %>
@@ -38,7 +38,7 @@ workflows:
                  - post_start_message_to_slack
 
             post_start_message_to_slack:
-              action: snpseq-packs.post_to_slack
+              action: snpseq_packs.post_to_slack
               input:
                 user: 'Bot D Liver'
                 emoji_icon: ':robot_face:'
@@ -48,7 +48,7 @@ workflows:
                  - get_pi_emails
 
             get_pi_emails:
-              action: snpseq-packs.read_projects_email_file
+              action: snpseq_packs.read_projects_email_file
               input:
                 file_path: <% $.projects_pi_email_file %>
                 projects:
@@ -60,7 +60,7 @@ workflows:
                 - get_pi_ids
 
             get_pi_ids:
-              action: snpseq-packs.get_pi_id_for_email_from_supr
+              action: snpseq_packs.get_pi_id_for_email_from_supr
               input:
                 project_to_email_sensitive_dict: <% $.projects_to_emails_sensitive %>
                 api_user: <% $.supr_api_user %>
@@ -72,7 +72,7 @@ workflows:
                 - stage_project
 
             stage_project:
-              action: snpseq-packs.delivery_service_stage_runfolders_for_project
+              action: snpseq_packs.delivery_service_stage_runfolders_for_project
               input:
                  mode: <% $.mode %>
                  delivery_base_api_url: <% $.delivery_service_url %>
@@ -86,7 +86,7 @@ workflows:
                 - create_delivery_projects
 
             create_delivery_projects:
-              action: snpseq-packs.create_delivery_project_in_super
+              action: snpseq_packs.create_delivery_project_in_super
               input:
                 project_names_and_ids: <% $.pi_supr_ids %>
                 staging_info: <% $.projects_and_stage_ids %>
@@ -101,7 +101,7 @@ workflows:
 
             # TODO Remember to pass correct md5sum files for the project.
             deliver_project:
-              action: snpseq-packs.delivery_service_deliver
+              action: snpseq_packs.delivery_service_deliver
               with-items: ngi_project_name in <% $.projects_and_stage_ids.keys() %>
               input:
                 ngi_project_name: <% $.ngi_project_name %>
@@ -116,7 +116,7 @@ workflows:
                 - check_delivery_status
 
             check_delivery_status:
-              action: snpseq-packs.delivery_service_delivery_status
+              action: snpseq_packs.delivery_service_delivery_status
               with-items:
                 - id in <% $.delivery_projects_and_ids.delivery_id %>
                 - ngi_project_name in <% $.delivery_projects_and_ids.project_name %>
@@ -132,7 +132,7 @@ workflows:
                 - post_finish_message_to_slack: <% $.skip_mover = true %>
 
             check_ngi_ready_status:
-              action: snpseq-packs.check_ngi_ready_in_supr
+              action: snpseq_packs.check_ngi_ready_in_supr
               with-items:
                 - project in <% $.delivery_projects.keys() %>
               input:
@@ -144,7 +144,7 @@ workflows:
                 - post_finish_message_to_slack
 
             post_finish_message_to_slack:
-              action: snpseq-packs.post_to_slack
+              action: snpseq_packs.post_to_slack
               input:
                 user: 'Bot D Liver'
                 emoji_icon: ':robot_face:'
@@ -152,7 +152,7 @@ workflows:
                 message: 'I just finished a runfolder delivery for `<% $.project_name %>`. You can see the details by running: `st2 execution get <% env().st2_execution_id %>`'
 
             post_failed_message_to_slack:
-              action: snpseq-packs.post_to_slack
+              action: snpseq_packs.post_to_slack
               input:
                 user: 'Bot D Liver'
                 emoji_icon: ':robot_face:'

--- a/actions/workflows/gather_ngi_pipeline_reports.yaml
+++ b/actions/workflows/gather_ngi_pipeline_reports.yaml
@@ -1,5 +1,5 @@
 version: "2.0" # mistral version
-name: snpseq-packs.gather_ngi_pipeline_reports
+name: snpseq_packs.gather_ngi_pipeline_reports
 description: Downloads ngi pipeline reports from e.g. irma to our summary host.
 
 workflows:
@@ -11,12 +11,12 @@ workflows:
               action: core.local
               input:
                 cmd: git rev-parse HEAD
-                cwd: /opt/stackstorm/packs/snpseq-packs/
+                cwd: /opt/stackstorm/packs/snpseq_packs/
               on-success:
                   - get_config
 
             get_config:
-              action: snpseq-packs.get_pack_config
+              action: snpseq_packs.get_pack_config
               publish:
                 summary_host: <% task(get_config).result.result.summary_host %>
                 summary_user: <% task(get_config).result.result.summary_user %>

--- a/actions/workflows/gather_project_reports.yaml
+++ b/actions/workflows/gather_project_reports.yaml
@@ -1,5 +1,5 @@
 version: "2.0" # mistral version
-name: snpseq-packs.gather_project_reports
+name: snpseq_packs.gather_project_reports
 description: Downloads summary statistics data from irma.
 
 workflows:
@@ -13,12 +13,12 @@ workflows:
               action: core.local
               input:
                 cmd: git rev-parse HEAD
-                cwd: /opt/stackstorm/packs/snpseq-packs/
+                cwd: /opt/stackstorm/packs/snpseq_packs/
               on-success:
                   - get_config
 
             get_config:
-              action: snpseq-packs.get_pack_config
+              action: snpseq_packs.get_pack_config
               publish:
                 summary_host: <% task(get_config).result.result.summary_host %>
                 summary_user: <% task(get_config).result.result.summary_user %>
@@ -39,7 +39,7 @@ workflows:
                 - check_for_runfolders
 
             check_for_runfolders:
-              action: snpseq-packs.get_remote_folder_list
+              action: snpseq_packs.get_remote_folder_list
               input:
                 directory: <% $.summary_destination %>/<% $.current_year %>/
                 username: <% $.summary_user %>

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -1,5 +1,5 @@
 version: "2.0" # mistral version
-name: snpseq-packs.ngi_uu_workflow
+name: snpseq_packs.ngi_uu_workflow
 description: The ngi workflow, from sequencer to remote system...
 
 workflows:
@@ -30,12 +30,12 @@ workflows:
               action: core.local
               input:
                 cmd: git rev-parse HEAD
-                cwd: /opt/stackstorm/packs/snpseq-packs/
+                cwd: /opt/stackstorm/packs/snpseq_packs/
               on-success:
                 - get_config
 
             get_config:
-              action: snpseq-packs.get_pack_config
+              action: snpseq_packs.get_pack_config
               publish:
                 remote_host: <% task(get_config).result.result.remote_host %>
                 remote_user: <% task(get_config).result.result.remote_user%>
@@ -83,7 +83,7 @@ workflows:
                 - get_flowcell_name
 
             get_flowcell_name:
-                action: snpseq-packs.get_flowcell_from_runfolder_name
+                action: snpseq_packs.get_flowcell_from_runfolder_name
                 input:
                     runfolder_name: <% $.runfolder_name %>
                 publish:
@@ -96,7 +96,7 @@ workflows:
             ### DEMULTIPLEX START ###
 
             download_samplesheet_mount:
-                action: snpseq-packs.download_samplesheet_mount
+                action: snpseq_packs.download_samplesheet_mount
                 input:
                     flowcell_name: <% $.flowcell_name %>
                     samplesheet_path: <% $.samplesheet_fallback_path %>
@@ -108,7 +108,7 @@ workflows:
                     - construct_bcl2fastq_body
 
             download_samplesheet_clarity:
-                action: snpseq-packs.download_samplesheet_clarity
+                action: snpseq_packs.download_samplesheet_clarity
                 input:
                     flowcell_name: <% $.flowcell_name %>
                 
@@ -122,7 +122,7 @@ workflows:
             # bcl2fastq-ws, we remove any empty keys from
             # this body.
             construct_bcl2fastq_body:
-                action: snpseq-packs.parse_bcl2fastq_args
+                action: snpseq_packs.parse_bcl2fastq_args
                 input:
                     samplesheet: "<% $.samplesheet_string %>"
                     bcl2fastq_version: "<% $.bcl2fastq_version %>"
@@ -137,7 +137,7 @@ workflows:
                     - run_bcl2fastq
 
             run_bcl2fastq:
-                action: snpseq-packs.poll_status
+                action: snpseq_packs.poll_status
                 input:
                     url: "http://<% $.host %>:<% $.bcl2fastq_service_port %>/api/1.0/start/<% $.runfolder_name %>"
                     timeout: 86400 # Wait for 24 h before timing out.
@@ -155,7 +155,7 @@ workflows:
             ## DEMULTIPLEX END ###
             ### CHECKQC START ###
             run_checkqc:
-              action: snpseq-packs.run_checkqc
+              action: snpseq_packs.run_checkqc
               input:
                 url: "http://<% $.host %>:<% $.checkqc_service_port %>/qc/<% $.runfolder_name %>"
                 ignore_result: <% $.ignore_qc_result %>
@@ -175,7 +175,7 @@ workflows:
 
             ### CHECK INDICES START###
             run_sisyphus_check_indices:
-                action: snpseq-packs.poll_status
+                action: snpseq_packs.poll_status
                 input:
                     url: "http://<% $.host %>:<% $.siswrap_service_port %>/api/1.0/checkindices/run/<% $.runfolder_name %>"
                     body:
@@ -197,7 +197,7 @@ workflows:
                 - rsync_to_summary_host
 
             rsync_to_summary_host:
-                action: snpseq-packs.rsync
+                action: snpseq_packs.rsync
                 input:
                     source: <% $.runfolder %>
                     source_host: <% $.host %>
@@ -210,7 +210,7 @@ workflows:
                     - run_projman_filler
 
             run_projman_filler:
-              action: snpseq-packs.run_projman_filler
+              action: snpseq_packs.run_projman_filler
               input:
                 hosts: <% $.summary_host %>
                 username: <% $.summary_user %>
@@ -224,7 +224,7 @@ workflows:
                 - rsync_to_irma
 
             rsync_to_irma:
-                action: snpseq-packs.sync_workflow
+                action: snpseq_packs.sync_workflow
                 input:
                     runfolder: <% $.runfolder %>
                     runfolder_name: <% $.runfolder_name %>
@@ -239,7 +239,7 @@ workflows:
                   - irma_check_md5sums
 
             irma_check_md5sums:
-                action: snpseq-packs.poll_status
+                action: snpseq_packs.poll_status
                 input:
                     url: <% $.irma_checksum_base_url %>/start/<% $.runfolder_name %>?apikey=<% $.irma_api_key %>
                     body:
@@ -253,7 +253,7 @@ workflows:
 
             ### START AEACUS REPORT STEPS ###
             irma_run_aeacus_stats:
-               action: snpseq-packs.poll_status
+               action: snpseq_packs.poll_status
                input:
                     url: <% $.irma_siswrap_base_url %>/aeacusstats/run/<% $.runfolder_name %>?apikey=<% $.irma_api_key %>
                     body:
@@ -264,7 +264,7 @@ workflows:
                  - irma_run_aeacus_reports
 
             irma_run_aeacus_reports:
-               action: snpseq-packs.poll_status
+               action: snpseq_packs.poll_status
                input:
                   url: <% $.irma_siswrap_base_url %>/aeacusreports/run/<% $.runfolder_name %>?apikey=<% $.irma_api_key %>
                   body:
@@ -289,7 +289,7 @@ workflows:
             ## START TSM ARCHIVE TO PDC ##
 
             upload_runfolder_to_pdc:
-                action: snpseq-packs.archive_upload
+                action: snpseq_packs.archive_upload
                 input:
                     runfolder: <% $.runfolder_name %>
                     host: <% $.host %>

--- a/actions/workflows/sync_workflow.yaml
+++ b/actions/workflows/sync_workflow.yaml
@@ -1,5 +1,5 @@
 version: "2.0" # mistral version
-name: snpseq-packs.sync_workflow
+name: snpseq_packs.sync_workflow
 description: Syncs a run for the source host to the remote_host.
 
 workflows:
@@ -24,14 +24,14 @@ workflows:
               action: core.local
               input:
                 cmd: git rev-parse HEAD
-                cwd: /opt/stackstorm/packs/snpseq-packs/
+                cwd: /opt/stackstorm/packs/snpseq_packs/
               on-success:
                  - create_md5sums_for_files_to_transfer
             ### GENERAL TASKS END ###
 
             ### TRANSFER FILES START ###
             create_md5sums_for_files_to_transfer:
-                action: snpseq-packs.create_sis_style_checksums
+                action: snpseq_packs.create_sis_style_checksums
                 input:
                     source: <% $.runfolder %>
                     host: <% $.source_host %>
@@ -43,7 +43,7 @@ workflows:
                     - rsync_to_destination
 
             rsync_to_destination:
-                action: snpseq-packs.rsync
+                action: snpseq_packs.rsync
                 input:
                     source: <% $.runfolder %>
                     source_host: <% $.source_host %>
@@ -56,7 +56,7 @@ workflows:
                     - rsync_md5sums
 
             rsync_md5sums:
-                action: snpseq-packs.rsync
+                action: snpseq_packs.rsync
                 input:
                     source: <% $.runfolder %>/MD5
                     source_host: <% $.source_host %>

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,5 +1,5 @@
 ---
-name: snpseq-packs
+name: snpseq_packs
 description: Pack for running sequencing center operations
 keywords:
   - sequencing

--- a/rules/charon_project_status.yaml
+++ b/rules/charon_project_status.yaml
@@ -1,6 +1,6 @@
 ---
-name: "snpseq-packs.charon_project_status"
-pack: "snpseq-packs"
+name: "snpseq_packs.charon_project_status"
+pack: "snpseq_packs"
 description: "Attempts to get the status OPEN projects in Charon and posts them to a Slack channel"
 enabled: true
 
@@ -14,6 +14,6 @@ trigger:
       second: 0
 
 action:
-    ref: "snpseq-packs.charon_project_status"
+    ref: "snpseq_packs.charon_project_status"
 
 

--- a/rules/check_irma_certs.yaml
+++ b/rules/check_irma_certs.yaml
@@ -1,6 +1,6 @@
 ---
-name: "snpseq-packs.check_irma_certs"
-pack: "snpseq-packs"
+name: "snpseq_packs.check_irma_certs"
+pack: "snpseq_packs"
 description: "Warn if Irma certs expire soon"
 enabled: true
 
@@ -13,5 +13,5 @@ trigger:
       second: 0
 
 action:
-    ref: "snpseq-packs.check_irma_certs"
+    ref: "snpseq_packs.check_irma_certs"
 

--- a/rules/gather_ngi_pipeline_reports.yaml
+++ b/rules/gather_ngi_pipeline_reports.yaml
@@ -1,6 +1,6 @@
 ---
-name: "snpseq-packs.gather_ngi_pipeline_reports"
-pack: "snpseq-packs"
+name: "snpseq_packs.gather_ngi_pipeline_reports"
+pack: "snpseq_packs"
 description: "Attempts to synchronize project reports from the ngi_pipeline at the set intervals."
 enabled: true
 
@@ -11,6 +11,6 @@ trigger:
       delta: 6
 
 action:
-    ref: "snpseq-packs.gather_ngi_pipeline_reports"
+    ref: "snpseq_packs.gather_ngi_pipeline_reports"
 
 

--- a/rules/gather_project_reports.yaml
+++ b/rules/gather_project_reports.yaml
@@ -1,6 +1,6 @@
 ---
-name: "snpseq-packs.gather_project_reports"
-pack: "snpseq-packs"
+name: "snpseq_packs.gather_project_reports"
+pack: "snpseq_packs"
 description: "Sync project reports from Irma to the summary host at the set intervals."
 enabled: true
 
@@ -11,4 +11,4 @@ trigger:
       delta: 2
 
 action:
-    ref: "snpseq-packs.gather_project_reports"
+    ref: "snpseq_packs.gather_project_reports"

--- a/rules/mv_runfolders_from_incoming_to_processing.yaml
+++ b/rules/mv_runfolders_from_incoming_to_processing.yaml
@@ -1,12 +1,12 @@
 ---
 
-name: "snpseq-packs.mv_runfolders_from_incoming_to_processing"
-pack: "snpseq-packs"
+name: "snpseq_packs.mv_runfolders_from_incoming_to_processing"
+pack: "snpseq_packs"
 description: "Checks the incoming runfolders service for runfolders that have been uploaded completely and moves them to the processing folder"
 enabled: true
 
 trigger:
-    type: "snpseq-packs.incoming_ready"
+    type: "snpseq_packs.incoming_ready"
 
 action:
     ref: "linux.mv"

--- a/rules/verify_random_archive.yaml
+++ b/rules/verify_random_archive.yaml
@@ -1,6 +1,6 @@
 ---
-name: "snpseq-packs.verify_random_archive"
-pack: "snpseq-packs"
+name: "snpseq_packs.verify_random_archive"
+pack: "snpseq_packs"
 description: "Verifies MD5sums for a randomly chosen, uploaded and unverified archive."
 enabled: true
 
@@ -14,5 +14,5 @@ trigger:
       second: 0
 
 action:
-    ref: "snpseq-packs.archive_verify_random"
+    ref: "snpseq_packs.archive_verify_random"
 

--- a/rules/when_runfolder_is_ready_run_ngi_pipeline.yaml
+++ b/rules/when_runfolder_is_ready_run_ngi_pipeline.yaml
@@ -1,13 +1,13 @@
 ---
-name: "snpseq-packs.when_runfolder_is_ready_run_ngi_pipeline"
+name: "snpseq_packs.when_runfolder_is_ready_run_ngi_pipeline"
 description: "Fires of the NGI pipeline when a runfolder is ready"
 enabled: true
 
 trigger:
-    type: "snpseq-packs.runfolder_ready"
+    type: "snpseq_packs.runfolder_ready"
 
 action:
-    ref: "snpseq-packs.ngi_uu_workflow"
+    ref: "snpseq_packs.ngi_uu_workflow"
     parameters:
         host: "{{trigger.host}}"
         runfolder: "{{trigger.runfolder}}"

--- a/scripts/follow-logs
+++ b/scripts/follow-logs
@@ -1,6 +1,6 @@
 #!/bin/bash
 what=$1
 if [ "$what" == "" ]; then
-    what="snpseq-packs"
+    what="snpseq_packs"
 fi
 tail -f /var/log/st2/* | grep -i "$what"

--- a/scripts/runfolder_search.py
+++ b/scripts/runfolder_search.py
@@ -13,7 +13,7 @@ else:
     sys.exit()
 
 # Load config
-with open("/opt/stackstorm/packs/snpseq-packs/config.yaml", 'r') as ymlfile:
+with open("/opt/stackstorm/packs/snpseq_packs/config.yaml", 'r') as ymlfile:
     cfg = yaml.load(ymlfile)
 
 # Get hosts from config

--- a/scripts/search-logs
+++ b/scripts/search-logs
@@ -1,7 +1,7 @@
 #!/bin/bash
 what=$1
 if [ "$what" == "" ]; then
-    what="snpseq-packs"
+    what="snpseq_packs"
 fi
 #grep $what /var/log/st2/* | less
 tac /var/log/st2/* | grep $what | less

--- a/scripts/setup-virtualenv
+++ b/scripts/setup-virtualenv
@@ -1,1 +1,1 @@
-st2 run packs.setup_virtualenv packs=snpseq-packs
+st2 run packs.setup_virtualenv packs=snpseq_packs

--- a/sensors/incoming_sensor.py
+++ b/sensors/incoming_sensor.py
@@ -8,7 +8,7 @@ class IncomingSensor(RunfolderSensor):
         super(IncomingSensor, self).__init__(sensor_service=sensor_service,
                                              config=config,
                                              poll_interval=poll_interval,
-                                             trigger='snpseq-packs.incoming_ready')
+                                             trigger='snpseq_packs.incoming_ready')
         self._logger = self._sensor_service.get_logger(__name__)
         self._infolog("__init__")
         self._client = None

--- a/sensors/runfolder_sensor.py
+++ b/sensors/runfolder_sensor.py
@@ -6,7 +6,7 @@ import os
 
 class RunfolderSensor(PollingSensor):
 
-    def __init__(self, sensor_service, config=None, poll_interval=None, trigger='snpseq-packs.runfolder_ready'):
+    def __init__(self, sensor_service, config=None, poll_interval=None, trigger='snpseq_packs.runfolder_ready'):
         super(RunfolderSensor, self).__init__(sensor_service=sensor_service,
                                               config=config,
                                               poll_interval=poll_interval)
@@ -73,10 +73,10 @@ class RunfolderSensor(PollingSensor):
         self._sensor_service.dispatch(trigger=trigger, payload=payload, trace_tag=runfolder_name)
 
     def _load_config(self):
-        config_path = "/opt/stackstorm/packs/snpseq-packs/config.yaml"
+        config_path = "/opt/stackstorm/packs/snpseq_packs/config.yaml"
         with open(config_path) as stream:
             self.config = yaml.load(stream)
             self._infolog("Loaded configuration from {}".format(config_path))
 
     def _infolog(self, msg):
-        self._logger.info("[snpseq-packs." + self.__class__.__name__ + "] " + msg)
+        self._logger.info("[snpseq_packs." + self.__class__.__name__ + "] " + msg)

--- a/utils/st2-check-register-pack-resources
+++ b/utils/st2-check-register-pack-resources
@@ -17,7 +17,7 @@
 # DOCS
 # This script has been adopted from st2-check-register-pack-resources
 # provided by StackStorm, but has been modified to work more easily
-# in the snpseq-packs environment.
+# in the snpseq_packs environment.
 #
 # The script which tries to register all the resources from a particular pack and
 # fails (exits with non-zero) if registering a particular resource fails.


### PR DESCRIPTION
**What problems does this PR solve?**
I'm currently working on bringing the current version of Stackstorm to our infrastructure. One of the necessary changes is that dashes are no longer permitted in pack names. Seeing as we are currently in the process of renaming the pack anyway, I think it is a good idea to implement this change now, to avoid having to rename everything twice.

@johandahlberg can you rename the repo here on Github again?

**How has the changes been tested?**
Deployed in `vagrant` and on `mm-xart001`. Tested some actions, but no workflows.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
