### PR TITLE
Charon project reports script should use proxy

### DIFF
--- a/actions/lib/charon_project_status.py
+++ b/actions/lib/charon_project_status.py
@@ -58,10 +58,15 @@ class CharonProjectStatus(Action):
         chcon.pretty_print(open_projects, output_handle)
         message = output_handle.getvalue()
         try:
+            proxies = None
+            if "slack_proxy_url" in self.config and self.config["slack_proxy_url"] != "":
+                proxies = {'http': self.config["slack_proxy_url"], 'https' : self.config["slack_proxy_url"] }
+
             sn = SlackNotifier(base_url=self.config["slack_webhook_url"],
                                channel=self.config["charon_status_report_slack_channel"],
                                user='WGS Status',
-                               icon_emoji=':see_no_evil:')
+                               icon_emoji=':see_no_evil:',
+                               proxies=proxies)
             sn.post_message_with_attachment(message="<!channel> Charon NGI-U open project status {} Z".
                                             format(datetime.datetime.utcnow().isoformat(' ')),
                                             attachment=message)

--- a/actions/lib/slack.py
+++ b/actions/lib/slack.py
@@ -1,5 +1,6 @@
 
 import requests
+from requests.exceptions import HTTPError
 from st2actions.runners.pythonrunner import Action
 
 
@@ -58,6 +59,10 @@ class SlackPoster(Action):
                                  proxies=proxies)
         try:
             notifier.post_message(message)
+            return True, ""
+        except HTTPError as e:
+            self.logger.error("Got the following HTTP error when trying to post to Slack: {}".format(e))
+            return False, ""
         except Exception as e:
             self.logger.error("Got error when trying to post to Slack: {}".format(e))
-            raise
+            return False, ""

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -12,7 +12,8 @@ class TestSlackPoster(BaseActionTestCase):
     def test_successful_post(self, notifier_mock):
         action = self.get_action_instance()
         action.config["slack_webhook_url"] = "this-is-the-webhook-url"
-        self.assertIsTrue(action.run("channel", "user", "message"))
+        exit_code, out = action.run("channel", "user", "message")
+        self.assertTrue(exit_code)
 
     @mock.patch("lib.slack.SlackNotifier", autospec=True)
     def test_unsuccessful_post(self, notifier_mock):
@@ -20,4 +21,5 @@ class TestSlackPoster(BaseActionTestCase):
         action.config["slack_webhook_url"] = "this-is-the-webhook-url"
         notifier = notifier_mock.return_value
         notifier.post_message.side_effect = requests.exceptions.HTTPError("a mock HTTPError")
-        self.assertIsFalse(action.run("channel", "user", "message"))
+        exit_code, out = action.run("channel", "user", "message")
+        self.assertFalse(exit_code)

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -12,7 +12,7 @@ class TestSlackPoster(BaseActionTestCase):
     def test_successful_post(self, notifier_mock):
         action = self.get_action_instance()
         action.config["slack_webhook_url"] = "this-is-the-webhook-url"
-        self.assertIsNone(action.run("channel", "user", "message"))
+        self.assertIsTrue(action.run("channel", "user", "message"))
 
     @mock.patch("lib.slack.SlackNotifier", autospec=True)
     def test_unsuccessful_post(self, notifier_mock):
@@ -20,5 +20,4 @@ class TestSlackPoster(BaseActionTestCase):
         action.config["slack_webhook_url"] = "this-is-the-webhook-url"
         notifier = notifier_mock.return_value
         notifier.post_message.side_effect = requests.exceptions.HTTPError("a mock HTTPError")
-        with self.assertRaises(requests.exceptions.HTTPError):
-            action.run("channel", "user", "message")
+        self.assertIsFalse(action.run("channel", "user", "message"))


### PR DESCRIPTION
**What problems does this PR solve?**
The Charon reports were not being posted, since they are not using the proxy. Now they do. Error reporting has also been improved.

**How has the changes been tested?**
I have tested this on the production instance, since I needed a machine behind the proxy to be sure everything worked as expected.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
