### PR TITLE
script for enabling or disabling all rules

### DIFF
--- a/scripts/rule_switch
+++ b/scripts/rule_switch
@@ -1,0 +1,2 @@
+# usage: rule_switch {enable|disable}
+st2 rule list -p snpseq_packs -a ref -y | awk '{print($3)}' |xargs -n1 st2 rule $1


### PR DESCRIPTION
**What problems does this PR solve?**
This PR introduces a script for quickly enable or disable all snpseq_packs rules. This will come in handy when deploying to the staging environment 

**How has the changes been tested?**
Tested on staging

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
