### PR TITLE
Lims integration links

### DIFF
--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -212,7 +212,7 @@ workflows:
             create_lims_integration_links:
                 action: core.remote
                 input:
-                    cmd: ln -s <% $.summary_destination %>/<% $.runfolder_name %> <% $.summary_destination %>/LIMS-integration/<% $.runfolder_name %>
+                    cmd: ln -s <% $.summary_destination %>/<% $.current_year %>/<% $.runfolder_name %> <% $.summary_destination %>/LIMS-integration/<% $.runfolder_name %>
                     hosts: <% $.summary_host %>
                     username: <% $.summary_user %>
                     private_key: <% $.summary_host_key %>

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -207,6 +207,16 @@ workflows:
                     destination: <% $.summary_destination %>/<% $.current_year %>
                     include_file: /etc/arteria/misc/summary.rsync
                 on-success:
+                    - create_lims_integration_links
+
+            create_lims_integration_links:
+                action: core.remote
+                input:
+                    cmd: ln -s <% $.summary_destination %>/<% $.runfolder_name %> <% $.summary_destination %>/LIMS-integration/<% $.runfolder_name %>
+                    hosts: <% $.summary_host %>
+                    username: <% $.summary_user %>
+                    private_key: <% $.summary_host_key %>
+                on-success:
                     - run_projman_filler
 
             run_projman_filler:


### PR DESCRIPTION
**What problems does this PR solve?**
This PR creates links from the seqsummaries runfolders to a subdir used for LIMS integration. This avoids reconfiguring LIMS-integration due to yearly subdirs in seqsummaries.

**How has the changes been tested?**
The modified workflow was sucessfully tested on mm-xart001.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
