### PR TITLE
WIP: New script for checking that referenced files and actions exist

### DIFF
--- a/scripts/check_referenced_files.py
+++ b/scripts/check_referenced_files.py
@@ -1,0 +1,109 @@
+import os
+import argparse
+import yaml
+import logging
+
+#
+# Script that parses all yaml files in actions and rules and checks
+# that all* referenced files exist. This script assumes that
+# action/rule/workflow name and file name are the same, e.g.
+# Workflow name: ngi_uu_workflow
+# File name: ngi_uu_workflow.yaml
+#
+# Keys searched for are specifically:
+# In actions:
+# - entry_point
+# - default (parameters -> workflow -> default)
+#
+# In workflows:
+# - action (workflows -> main -> tasks -> <task_name> -> action)
+#
+# In rules:
+# - ref (action -> ref)
+#
+# * Not really all:
+# TODO: Referenced actions should probably be compared with action names rather
+# than file name. Because of the current implementation sensors are not included
+# in check.
+
+def find(d, tag):
+    if tag in d:
+        logger.debug("Found tag: {}, with value: {}".format(tag,d[tag]))
+        yield d[tag]
+    for k, v in d.items():
+        if isinstance(v, dict):
+            for i in find(v, tag):
+                yield i
+
+def check_action(pack_location, file, action):
+    if os.path.isfile(os.path.join(pack_location,"actions","{}.yaml".format(action))):
+        logger.debug("In file {}: {} exists".format(file, action))
+    else:
+        logger.error("In file {}: {} does not exist!".format(file, action))
+
+def check_file(pack_location, parsed_file, referenced_file):
+    if os.path.isfile(os.path.join(pack_location,"actions",referenced_file)):
+        logger.debug("In file {}: {} exists".format(parsed_file, referenced_file))
+    else:
+        logger.error("In file {}: {} does not exist!".format(parsed_file, referenced_file))
+
+def check_files_in_folder(folder_path, tags):
+    for file in os.listdir(os.path.join(pack_location,folder_path)):
+        logger.debug("Found file: {} in {}".format(file, folder_path))
+        if file.endswith(".yaml"):
+            logger.debug("Found file, {}, is a yaml file".format(file))
+            full_path_file = os.path.join(pack_location,folder_path,file)
+            yaml_dict = yaml.load(open(full_path_file))
+            for tag in tags:
+                if tag == "workflow":
+                    for ref in find(yaml_dict, tag):
+                        workflow = ref["default"]
+                        pack, action = workflow.split(".")
+                        if pack == "snpseq_packs":
+                            check_action(pack_location, full_path_file, action)
+                else:
+                    for ref in find(yaml_dict, tag):
+                        if tag == "entry_point":
+                            # Some runner types like run-local or remote-shell-cmd
+                            # have no value for entry_point
+                            if ref != '':
+                                check_file(pack_location, full_path_file, ref)
+                        else:
+                            if "." in ref:
+                                pack, action = ref.split(".")
+                                if pack == "snpseq_packs":
+                                    check_action(pack_location, full_path_file, action)
+                            else:
+                                check_action(pack_location, full_path_file, ref)
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Check that all referenced \
+                                     files in rules and actions exist")
+    parser.add_argument('-p','--pack-location', required = True)
+    parser.add_argument('-d','--debug', action='store_true')
+    args = parser.parse_args()
+
+    pack_location = args.pack_location
+    debug_mode = args.debug
+
+    logger = logging.getLogger('check_referenced_files')
+
+    if debug_mode:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
+
+    ch = logging.StreamHandler()
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+    # Check actions
+    check_files_in_folder("actions", ["entry_point", "workflow"])
+
+    # Check workflows
+    check_files_in_folder("actions/workflows", ["action"])
+
+    # Check rules
+    check_files_in_folder("rules", ["ref"])


### PR DESCRIPTION
**What problems does this PR solve?**
This script was made in an attempt to validate #40 . Given the pack location, it parses all files in `actions` , `actions/workflows` and `rules` to confirm that actions/files (not sensors/triggers) that are referenced do exist. However, it turned out to be a bit more work than planned, so I'm going to leave it here for now. It does not cover all referenced files, but at least it's a start. 

In the current implementation, the following errors are found: 
```
2018-10-11 13:31:33,840 - check_referenced_files - ERROR - In file snpseq_packs/actions/delivery_runfolders_for_project_workflow.yaml: delivery_runfolers_for_workflow does not exist!
2018-10-11 13:31:33,967 - check_referenced_files - ERROR - In file snpseq_packs/actions/workflows/delivery_runfolders_for_project_workflow.yaml: create_delivery_project_in_super does not exist!
2018-10-11 13:31:33,987 - check_referenced_files - ERROR - In file snpseq_packs/actions/workflows/delivery_project_workflow.yaml: create_delivery_project_in_super does not exist!
2018-10-11 13:31:34,088 - check_referenced_files - ERROR - In file snpseq_packs/actions/workflows/delivery_runfolder_workflow.yaml: create_delivery_project_in_super does not exist!
```
Thoughts on the errors: 
**create_delivery_project_in_super:**
This is due to the action being named `create_delivery_project_in_super` while the file is called `create_delivery_project_in_supr`. The current implementation assumes that action name and file name should be the same. This is not required by the framework, but maybe something we want for clarity. In this case the action name is actually a typo, so I think it should be fixed. 

**delivery_runfolers_for_workflow**:
It's a typo in the default value for the parameter workflow in `delivery_runfolders_for_project_workflow.yaml`. This parameter is used to specify which workflow to run in a workflow file. We never use the workflow parameter when running workflows, so I would assume that the default value is used, so I find it fascinating that this workflow is not broken. 

When looking in to it: All of our workflows are named `main` in each workflow file, so the correct way to specify `workflow` would in this case be :
```
workflow:
  default: snpseq_packs.delivery_runfolders_for_workflow.main
```

So, since not everything is broken, my guess is that when the default value is not found, the `main` workflow is run. I've glanced at the documentation and was not able to confirm this, but it might be found by putting more effort in.

**How has the changes been tested?**
 I've tested it manually, elaborately adding typos to references and it **looks** like it works, but automatic tests would be needed. 

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
