### PR TITLE
Move lims integration step

### DIFF
--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -1,4 +1,4 @@
-gersion: "2.0" # mistral version
+version: "2.0" # mistral version
 name: snpseq_packs.ngi_uu_workflow
 description: The ngi workflow, from sequencer to remote system...
 

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -89,11 +89,42 @@ workflows:
                 publish:
                     flowcell_name: <% task(get_flowcell_name).result.result %>
                 on-success:
-                    - download_samplesheet_mount: <% $.skip_download_samplesheet_mount = false %>
-                    - download_samplesheet_clarity: <% $.skip_download_samplesheet_mount = true %>
+                    - get_year
+
+            get_year:
+              action: core.local
+              input:
+                cmd: echo 20$(echo <% $.runfolder_name %> | cut -c1-2)
+              publish:
+                current_year: <% task(get_year).result.stdout %>
+              on-success:
+                - rsync_to_summary_host_before_demultiplexing
 
             ### GENERAL TASKS END ###
             ### DEMULTIPLEX START ###
+            rsync_to_summary_host_before_demultiplexing:
+                action: snpseq_packs.rsync
+                input:
+                    source: <% $.runfolder %>
+                    source_host: <% $.host %>
+                    source_host_user: "arteria"
+                    dest_server: <% $.summary_host %>
+                    dest_user: <% $.summary_user %>
+                    destination: <% $.summary_destination %>/<% $.current_year %>
+                    include_file: /etc/arteria/misc/summary.rsync
+                on-success:
+                    - create_lims_integration_links
+
+            create_lims_integration_links:
+                action: core.remote
+                input:
+                    cmd: ln -s -f <% $.summary_destination %>/<% $.current_year %>/<% $.runfolder_name %> <% $.summary_destination %>/LIMS-integration/<% $.runfolder_name %>
+                    hosts: <% $.summary_host %>
+                    username: <% $.summary_user %>
+                    private_key: <% $.summary_host_key %>
+                on-success:
+                    - download_samplesheet_mount: <% $.skip_download_samplesheet_mount = false %>
+                    - download_samplesheet_clarity: <% $.skip_download_samplesheet_mount = true %>
 
             download_samplesheet_mount:
                 action: snpseq_packs.download_samplesheet_mount
@@ -182,20 +213,11 @@ workflows:
                       runfolder: <% $.runfolder_name %>
                     ignore_result: <% $.ignore_qc_result %>
                 on-success:
-                    - get_year: <% task(run_checkqc).state = 'SUCCESS'  %>
+                    - rsync_to_summary_host: <% task(run_checkqc).state = 'SUCCESS'  %>
                     - oh_shit_error: <% task(run_checkqc).state = 'ERROR' %>
                     - mark_as_failed: <% task(run_checkqc).state = 'ERROR' %>
             ### CHECK INDICES END###
             ### TRANSFER FILES TO UPPMAX START ###
-            get_year:
-              action: core.local
-              input:
-                cmd: echo 20$(echo <% $.runfolder_name %> | cut -c1-2)
-              publish:
-                current_year: <% task(get_year).result.stdout %>
-              on-success:
-                - rsync_to_summary_host
-
             rsync_to_summary_host:
                 action: snpseq_packs.rsync
                 input:
@@ -206,16 +228,6 @@ workflows:
                     dest_user: <% $.summary_user %>
                     destination: <% $.summary_destination %>/<% $.current_year %>
                     include_file: /etc/arteria/misc/summary.rsync
-                on-success:
-                    - create_lims_integration_links
-
-            create_lims_integration_links:
-                action: core.remote
-                input:
-                    cmd: ln -s -f <% $.summary_destination %>/<% $.current_year %>/<% $.runfolder_name %> <% $.summary_destination %>/LIMS-integration/<% $.runfolder_name %>
-                    hosts: <% $.summary_host %>
-                    username: <% $.summary_user %>
-                    private_key: <% $.summary_host_key %>
                 on-success:
                     - run_projman_filler
 

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -1,4 +1,4 @@
-version: "2.0" # mistral version
+gersion: "2.0" # mistral version
 name: snpseq_packs.ngi_uu_workflow
 description: The ngi workflow, from sequencer to remote system...
 
@@ -272,9 +272,24 @@ workflows:
                     verify_ssl_cert: True
                     irma_mode: True
                 on-success:
+                  - upload_runfolder_to_pdc: <% $.skip_archiving = false %>
                   - irma_run_aeacus_stats
 
             ### TRANSFER FILES TO UPPMAX END ###
+
+            ## START TSM ARCHIVE TO PDC ##
+
+            upload_runfolder_to_pdc:
+                action: snpseq_packs.archive_upload_workflow
+                input:
+                    runfolder: <% $.runfolder_name %>
+                    host: <% $.host %>
+                    remove_previous_archive: <% $.remove_previous_archive_dir %>
+                on-success:
+                  - notify_finished
+                  - mark_as_finished
+
+            ## END TSM ARCHIVE TO PDC ##
 
             ### START AEACUS REPORT STEPS ###
             irma_run_aeacus_stats:
@@ -297,9 +312,8 @@ workflows:
                   verify_ssl_cert: True
                   irma_mode: True
                on-success:
-                - upload_runfolder_to_pdc: <% $.skip_archiving = false %>
-                - notify_finished: <% $.skip_archiving = true %>
-                - mark_as_finished: <% $.skip_archiving = true %>
+                 - notify_finished: <% $.skip_archiving = true %>
+                 - mark_as_finished: <% $.skip_archiving = true %>
 
             ### END AEACUS REPORT STEPS ###
 
@@ -310,20 +324,6 @@ workflows:
             #  input:
             #    url: <% $.ngi_pipeline_url %>/<% $.runfolder_name %>
             ## END START NGI_PIPELINE ##
-
-            ## START TSM ARCHIVE TO PDC ##
-
-            upload_runfolder_to_pdc:
-                action: snpseq_packs.archive_upload_workflow
-                input:
-                    runfolder: <% $.runfolder_name %>
-                    host: <% $.host %>
-                    remove_previous_archive: <% $.remove_previous_archive_dir %>
-                on-success:
-                  - notify_finished
-                  - mark_as_finished
-
-            ## END TSM ARCHIVE TO PDC ##
 
             ## NOTIFIER START ###
             notify_finished:


### PR DESCRIPTION
**What problems does this PR solve?**
The LIMS integration step is now performed before demultiplexing so that integration with the lims won't be halted if demultiplexing or QC check fail. We realized that this was necessary for the "NovaSeq Automated" protocol, since the "Start Illumina Sequencing" step will not terminate until run data has been read. This made us end up in a situation where the QC check had failed, but no bioinformatician could start working on this run since it had not been moved from "Start Illumina Seqencing" to the Bioinfo protocol. Catch 22. 

EDIT 20181015:
Additional change: archive_upload_workflow and aeacus jobs are now started in parallel. 

**How has the changes been tested?**
Will be validated in staging environment. 

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
