### PR TITLE
ART-115: make irma user and keys configurable

### DIFF
--- a/actions/workflows/check_irma_certs_workflow.yaml
+++ b/actions/workflows/check_irma_certs_workflow.yaml
@@ -29,6 +29,7 @@ workflows:
                 summary_host: <% task(get_config).result.result.summary_host %>
                 summary_user: <% task(get_config).result.result.summary_user %>
                 summary_host_key: <% task(get_config).result.result.summary_host_key %>
+                irma_cert: <% task(get_config).result.result.irma_summary_ssh_cert %>
                 slack_channel: <% task(get_config).result.result.check_cert_slack_channel %>
               on-success:
                  - get_summary_cert_expiry
@@ -37,7 +38,7 @@ workflows:
             get_summary_cert_expiry:
               action: core.remote
               input:
-                cmd: EXPIRE=`ssh-keygen -L -f /home/seqsum/.ssh/mm-xlas002-cert.pub | grep Valid | awk '{print $5 }'` && DIFF=$((`date -d "${EXPIRE}" +%s`-`date +%s`)) && if [ ${DIFF} -lt $((60*60*24*<% $.days %>)) ]; then echo "SSH certificate expires within <% $.days %> days!" && false; fi
+                cmd: EXPIRE=`ssh-keygen -L -f <% $.irma_cert %> | grep Valid | awk '{print $5 }'` && DIFF=$((`date -d "${EXPIRE}" +%s`-`date +%s`)) && if [ ${DIFF} -lt $((60*60*24*<% $.days %>)) ]; then echo "SSH certificate expires within <% $.days %> days!" && false; fi
                 hosts: <% $.summary_host %>
                 username: <% $.summary_user %>
                 private_key: <% $.summary_host_key %>

--- a/actions/workflows/gather_ngi_pipeline_reports_workflow.yaml
+++ b/actions/workflows/gather_ngi_pipeline_reports_workflow.yaml
@@ -24,6 +24,7 @@ workflows:
                 irma_reports_remote_path: <% task(get_config).result.result.irma_reports_remote_path %>
                 irma_user: <% task(get_config).result.result.irma_summary_ssh_user %>
                 irma_key: <% task(get_config).result.result.irma_summary_ssh_key %>
+                irma_host: <% task(get_config).result.result.irma_summary_host %>
                 summary_host_key: <% task(get_config).result.result.summary_host_key %>
               on-success:
                 - rsync_from_irma
@@ -31,7 +32,7 @@ workflows:
             rsync_from_irma:
               action: core.remote
               input:
-                cmd: rsync -e "ssh -i <% $.irma_key %>" -r <% $.irma_user %>@irma1.uppmax.uu.se:<% $.irma_reports_remote_path %>/ <% $.summary_ngi_pipeline_reports_destination %>/
+                cmd: rsync -e "ssh -i <% $.irma_key %>" -r <% $.irma_user %>@<% $.irma_host %>:<% $.irma_reports_remote_path %>/ <% $.summary_ngi_pipeline_reports_destination %>/
                 hosts: <% $.summary_host %>
                 username: <% $.summary_user %>
                 private_key: <% $.summary_host_key %>

--- a/actions/workflows/gather_ngi_pipeline_reports_workflow.yaml
+++ b/actions/workflows/gather_ngi_pipeline_reports_workflow.yaml
@@ -22,6 +22,8 @@ workflows:
                 summary_user: <% task(get_config).result.result.summary_user %>
                 summary_ngi_pipeline_reports_destination: <% task(get_config).result.result.summary_ngi_pipeline_reports_destination %>
                 irma_reports_remote_path: <% task(get_config).result.result.irma_reports_remote_path %>
+                irma_user: <% task(get_config).result.result.irma_summary_ssh_user %>
+                irma_key: <% task(get_config).result.result.irma_summary_ssh_key %>
                 summary_host_key: <% task(get_config).result.result.summary_host_key %>
               on-success:
                 - rsync_from_irma
@@ -29,7 +31,7 @@ workflows:
             rsync_from_irma:
               action: core.remote
               input:
-                cmd: rsync -e "ssh -i /home/seqsum/.ssh/mm-xlas002" -r funk_901@irma1.uppmax.uu.se:<% $.irma_reports_remote_path %>/ <% $.summary_ngi_pipeline_reports_destination %>/
+                cmd: rsync -e "ssh -i <% $.irma_key %>" -r <% $.irma_user %>@irma1.uppmax.uu.se:<% $.irma_reports_remote_path %>/ <% $.summary_ngi_pipeline_reports_destination %>/
                 hosts: <% $.summary_host %>
                 username: <% $.summary_user %>
                 private_key: <% $.summary_host_key %>

--- a/actions/workflows/gather_project_reports_workflow.yaml
+++ b/actions/workflows/gather_project_reports_workflow.yaml
@@ -25,6 +25,8 @@ workflows:
                 summary_host_key: <% task(get_config).result.result.summary_host_key %>
                 summary_destination: <% task(get_config).result.result.summary_destination %>
                 irma_remote_path: <% task(get_config).result.result.irma_remote_path %>
+                irma_user: <% task(get_config).result.result.irma_summary_ssh_user %>
+                irma_key: <% task(get_config).result.result.irma_summary_ssh_key %>
               on-success:
                  - get_year
 
@@ -63,7 +65,7 @@ workflows:
                 #   potentially leading to us missing real errors.
                 # - Filtering for downstream insertion into the database is carried out by the check_reports_old_enough
                 #   which will only return the runfolders with valid summary reports for processing.
-                cmd: rsync -e "ssh -i /home/seqsum/.ssh/mm-xlas002" -r --times funk_901@irma1.uppmax.uu.se:<% $.irma_remote_path %>/<% $.runfolder %>/Summary <% $.summary_destination %>/<% $.current_year %>/<% $.runfolder %>/; if (( $? == 0 || $? == 23 )) ; then true; else false; fi
+                cmd: rsync -e "ssh -i <% $.irma_key %>" -r --times <% $.irma_user %>@irma1.uppmax.uu.se:<% $.irma_remote_path %>/<% $.runfolder %>/Summary <% $.summary_destination %>/<% $.current_year %>/<% $.runfolder %>/; if (( $? == 0 || $? == 23 )) ; then true; else false; fi
                 hosts: <% $.summary_host %>
                 username: <% $.summary_user %>
                 private_key: <% $.summary_host_key %>

--- a/actions/workflows/gather_project_reports_workflow.yaml
+++ b/actions/workflows/gather_project_reports_workflow.yaml
@@ -27,6 +27,7 @@ workflows:
                 irma_remote_path: <% task(get_config).result.result.irma_remote_path %>
                 irma_user: <% task(get_config).result.result.irma_summary_ssh_user %>
                 irma_key: <% task(get_config).result.result.irma_summary_ssh_key %>
+                irma_host: <% task(get_config).result.result.irma_summary_host %>
               on-success:
                  - get_year
 
@@ -65,7 +66,7 @@ workflows:
                 #   potentially leading to us missing real errors.
                 # - Filtering for downstream insertion into the database is carried out by the check_reports_old_enough
                 #   which will only return the runfolders with valid summary reports for processing.
-                cmd: rsync -e "ssh -i <% $.irma_key %>" -r --times <% $.irma_user %>@irma1.uppmax.uu.se:<% $.irma_remote_path %>/<% $.runfolder %>/Summary <% $.summary_destination %>/<% $.current_year %>/<% $.runfolder %>/; if (( $? == 0 || $? == 23 )) ; then true; else false; fi
+                cmd: rsync -e "ssh -i <% $.irma_key %>" -r --times <% $.irma_user %>@<% $.irma_host %>:<% $.irma_remote_path %>/<% $.runfolder %>/Summary <% $.summary_destination %>/<% $.current_year %>/<% $.runfolder %>/; if (( $? == 0 || $? == 23 )) ; then true; else false; fi
                 hosts: <% $.summary_host %>
                 username: <% $.summary_user %>
                 private_key: <% $.summary_host_key %>

--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,7 @@ irma_reports_remote_path: ./staging/reports/
 irma_summary_ssh_user: user
 irma_summary_ssh_key: /path/to/ssh/key
 irma_summary_ssh_cert: /path/to/ssh/cert
+irma_summary_host: irma1.uppmax.uu.se
 irma_checksum_base_url: https://irma1.uppmax.uu.se:4444/arteria_checksum_staging/api/1.0
 irma_siswrap_base_url: https://irma1.uppmax.uu.se:4444/arteria_siswrap_staging/api/1.0
 irma_archive_upload_base_url: https://irma1.uppmax.uu.se:4444/arteria_archive_staging/api/1.0

--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,9 @@ ngi_pipeline_url: https://irma1.uppmax.uu.se:4444/ngi_pipeline_upps
 irma_api_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 irma_remote_path: ./staging/
 irma_reports_remote_path: ./staging/reports/
+irma_summary_ssh_user: user
+irma_summary_ssh_key: /path/to/ssh/key
+irma_summary_ssh_cert: /path/to/ssh/cert
 irma_checksum_base_url: https://irma1.uppmax.uu.se:4444/arteria_checksum_staging/api/1.0
 irma_siswrap_base_url: https://irma1.uppmax.uu.se:4444/arteria_siswrap_staging/api/1.0
 irma_archive_upload_base_url: https://irma1.uppmax.uu.se:4444/arteria_archive_staging/api/1.0


### PR DESCRIPTION
**What problems does this PR solve?**
The new summary host is currently unable to fetch reports from irma (ART-115).
The problem is twofold:
1. the new machine is currently not able to log in on irma. We are trying to resolve the issue with UPPMAX support
2. the workflow uses hard coded values for the key files

This PR tackles the latter problem. And while I'm at it, I also made the user configurable.

**How has the changes been tested?**
The changes haven't been tested yet. I think it makes most sense to test them once we can actually log in on `irma1`.
Additionally there will be an accompanying PR in the system-management repo which is aware of the new config values.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
