### PR TITLE
ART-128: Linking for the LIMS integration should use -n

### DIFF
--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -118,7 +118,7 @@ workflows:
             create_lims_integration_links:
                 action: core.remote
                 input:
-                    cmd: ln -s -f <% $.summary_destination %>/<% $.current_year %>/<% $.runfolder_name %> <% $.summary_destination %>/LIMS-integration/<% $.runfolder_name %>
+                    cmd: ln -n -s -f <% $.summary_destination %>/<% $.current_year %>/<% $.runfolder_name %> <% $.summary_destination %>/LIMS-integration/<% $.runfolder_name %>
                     hosts: <% $.summary_host %>
                     username: <% $.summary_user %>
                     private_key: <% $.summary_host_key %>


### PR DESCRIPTION
**What problems does this PR solve?**
We need to use -n to make sure that the link name is not dereferenced, which creates a loop otherwise.

**How has the changes been tested?**
The function of the `ln` command has been tested locally, but no other testing has been run.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
