### PR TITLE
Bio 1559 check supr

### DIFF
--- a/actions/check_clarity_contacts_in_supr.py
+++ b/actions/check_clarity_contacts_in_supr.py
@@ -6,6 +6,10 @@ from genologics.lims import *
 from genologics.config import BASEURI, USERNAME, PASSWORD
 from lib.supr_utils import * 
 
+#disable ssl warnings
+import requests.packages.urllib3
+requests.packages.urllib3.disable_warnings()
+
 
 class CheckClarityContactsInSupr(Action):
     """
@@ -13,6 +17,7 @@ class CheckClarityContactsInSupr(Action):
     SUPR accounts by email.
     Then composes an email body to notify project coordinators.
     """
+
     def fetch_open_projects(self):
         lims = Lims(BASEURI, USERNAME, PASSWORD)
         lims.check_version()
@@ -21,31 +26,73 @@ class CheckClarityContactsInSupr(Action):
 	for project in projects:
 		if project.open_date and not project.close_date:
 			filtered_projects.append(project)
-			
         return filtered_projects
 
-    def check_email_in_supr(email_adress):
-    	supr_utils.search_by_email(base_url, email_adress, user, key)
+    def check_email_in_supr(self, email_adress):
+        email_missing = False
+        email_multi = False
 
+        try:
+            pi_id = SuprUtils.search_by_email(self.supr_base_url, email_adress, self.supr_user, self.supr_key)
+        except AssertionError as ae:
+            if ("no hits" in ae.message):
+                email_missing = True
+            elif ("more than one" in ae.message):
+                email_multi = True
 
-    def run(self): #supr_base_api_url, api_user, api_key
-        #fetch projects
+        return (email_missing, email_multi)
+
+    def run(self): #supr_base_url, supr_user, supr_key
+        #TODO:debug vars, remove
+	supr_base_url = "https://supr.snic.se/api"
+	supr_user = "api-2"
+	supr_key= "Acgxd6Hvns"
+
+        self.supr_base_url = supr_base_url
+        self.supr_user = supr_user
+        self.supr_key = supr_key
+
         projects = self.fetch_open_projects()
+	email_body = ""
+        debug_break = 30 #TODO: remove
 	for project in projects:
-		pi_email = project.udf.get("Email of PI")
-		bio_email = project.udf.get("Email of bioinformatics responsible person")
-		#primary_email = project.udf.get("Email of primary contact")
+            pi_missing = False
+            pi_multi = False
+            bio_missing = False
+            bio_multi = False
 
-		if (pi_email):
-			check_email_in_supr(pi_email)
+            debug_break =- 1        #TODO: remove
+            if (debug_break == 0):
+                break
+
+            pi_email = project.udf.get("Email of PI")
+            bio_email = project.udf.get("Email of bioinformatics responsible person")
+            #primary_email = project.udf.get("Email of primary contact")
+            if (pi_email):
+                (pi_missing, pi_multi) = self.check_email_in_supr(pi_email) 
+  
+            if (bio_email):
+                (bio_missing, bio_multi) = self.check_email_in_supr(bio_email)
+ 
+            if (pi_missing or pi_multi or bio_missing or bio_multi):
+                pi_name = project.udf.get("Name of PI")
+                if (not pi_name):
+                    pi_name = "Name missing from LIMS"
+                bio_name = project.udf.get("Name of bioinformatics responsible person")
+                if (not bio_name):
+                    bio_name = "Name missing from LIMS"
+                email_body += "<hr>Project: " + project.name + ": <br><br>"
+
+                if (pi_missing):
+                    email_body += "PI missing from SUPR ( " + pi_name + ", " + pi_email + " )<br>"
+                if (pi_multi):
+                    email_body += "PI has multiple accounts in SUPR ( " + pi_name + ", " + pi_email + " )<br>"
+                if (bio_missing):
+                    email_body += "BIO missing from SUPR ( " + bio_name + ", " + bio_email + " )<br>"
+                if (bio_multi):
+                    email_body += "BIO has multiple accounts in SUPR ( " + bio_name + ", " + bio_email + " )<br>"
+
+        return (True, email_body)
 
 
 
-
-		print "---------------------"
-		print project.open_date
-		print project.close_date
-		print "---------------------"
-        #Retrieve contacs
-
-        #Check SUPR

--- a/actions/check_clarity_contacts_in_supr.py
+++ b/actions/check_clarity_contacts_in_supr.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+from st2actions.runners.pythonrunner import Action
+
+from genologics.lims import *
+from genologics.config import BASEURI, USERNAME, PASSWORD
+from lib.supr_utils import * 
+
+
+class CheckClarityContactsInSupr(Action):
+    """
+    Retrives contacts from open projects in ClarityLIMS and checks for
+    SUPR accounts by email.
+    Then composes an email body to notify project coordinators.
+    """
+    def fetch_open_projects(self):
+        lims = Lims(BASEURI, USERNAME, PASSWORD)
+        lims.check_version()
+        projects = lims.get_projects() 
+	filtered_projects = list()
+	for project in projects:
+		if project.open_date and not project.close_date:
+			filtered_projects.append(project)
+			
+        return filtered_projects
+
+    def check_email_in_supr(email_adress):
+    	supr_utils.search_by_email(base_url, email_adress, user, key)
+
+
+    def run(self): #supr_base_api_url, api_user, api_key
+        #fetch projects
+        projects = self.fetch_open_projects()
+	for project in projects:
+		pi_email = project.udf.get("Email of PI")
+		bio_email = project.udf.get("Email of bioinformatics responsible person")
+		#primary_email = project.udf.get("Email of primary contact")
+
+		if (pi_email):
+			check_email_in_supr(pi_email)
+
+
+
+
+		print "---------------------"
+		print project.open_date
+		print project.close_date
+		print "---------------------"
+        #Retrieve contacs
+
+        #Check SUPR

--- a/actions/check_clarity_contacts_in_supr.py
+++ b/actions/check_clarity_contacts_in_supr.py
@@ -33,7 +33,7 @@ class CheckClarityContactsInSupr(Action):
         email_multi = False
 
         try:
-            pi_id = SuprUtils.search_by_email(self.supr_base_url, email_adress, self.supr_user, self.supr_key)
+            supr_id = SuprUtils.search_by_email(self.supr_base_url, email_adress, self.supr_user, self.supr_key)
         except AssertionError as ae:
             if ("no hits" in ae.message):
                 email_missing = True
@@ -42,11 +42,7 @@ class CheckClarityContactsInSupr(Action):
 
         return (email_missing, email_multi)
 
-    def run(self): #supr_base_url, supr_user, supr_key
-        #TODO:debug vars, remove
-	supr_base_url = "https://supr.snic.se/api"
-	supr_user = "api-2"
-	supr_key= "Acgxd6Hvns"
+    def run(self, supr_base_url, supr_user, supr_key):
 
         self.supr_base_url = supr_base_url
         self.supr_user = supr_user
@@ -54,25 +50,24 @@ class CheckClarityContactsInSupr(Action):
 
         projects = self.fetch_open_projects()
 	email_body = ""
-        debug_break = 30 #TODO: remove
 	for project in projects:
             pi_missing = False
             pi_multi = False
             bio_missing = False
             bio_multi = False
 
-            debug_break =- 1        #TODO: remove
-            if (debug_break == 0):
-                break
-
             pi_email = project.udf.get("Email of PI")
             bio_email = project.udf.get("Email of bioinformatics responsible person")
             #primary_email = project.udf.get("Email of primary contact")
+
             if (pi_email):
+		pi_email = pi_email.strip()
                 (pi_missing, pi_multi) = self.check_email_in_supr(pi_email) 
   
             if (bio_email):
+		bio_email = bio_email.strip()
                 (bio_missing, bio_multi) = self.check_email_in_supr(bio_email)
+
  
             if (pi_missing or pi_multi or bio_missing or bio_multi):
                 pi_name = project.udf.get("Name of PI")

--- a/actions/check_clarity_contacts_in_supr.py
+++ b/actions/check_clarity_contacts_in_supr.py
@@ -60,7 +60,7 @@ class CheckClarityContactsInSupr(Action):
                 if not (account_missing or multiple_accounts):
                     continue
                 name = project.udf.get("Name of {}".format(role)) or "Name missing from LIMS"
-                email_body += "{}: {} {} SUPR {}<br>".format(project.name, role, "missing from" if account_missing else "has multiple accounts in", "( {}, {} )".format(name, email))
+                email_body += "{}: {} {} SUPR {}<br><hr>".format(project.name, role, "missing from" if account_missing else "has multiple accounts in", "( {}, {} )".format(name, email))
 
         return (True, email_body)
 

--- a/actions/check_clarity_contacts_in_supr.py
+++ b/actions/check_clarity_contacts_in_supr.py
@@ -33,7 +33,7 @@ class CheckClarityContactsInSupr(Action):
         email_multi = False
 
         try:
-            supr_id = SuprUtils.search_by_email(self.supr_base_url, email_adress, self.supr_user, self.supr_key)
+            supr_id = SuprUtils.search_by_email(self.supr_api_url, email_adress, self.supr_api_user, self.supr_api_key)
         except AssertionError as ae:
             if ("no hits" in ae.message):
                 email_missing = True
@@ -42,11 +42,11 @@ class CheckClarityContactsInSupr(Action):
 
         return (email_missing, email_multi)
 
-    def run(self, supr_base_url, supr_user, supr_key):
+    def run(self, supr_api_url, supr_api_user, supr_api_key):
 
-        self.supr_base_url = supr_base_url
-        self.supr_user = supr_user
-        self.supr_key = supr_key
+        self.supr_api_url = supr_api_url
+        self.supr_api_user = supr_api_user
+        self.supr_api_key = supr_api_key
 
         projects = self.fetch_open_projects()
 	email_body = ""

--- a/actions/check_clarity_contacts_in_supr.py
+++ b/actions/check_clarity_contacts_in_supr.py
@@ -60,7 +60,7 @@ class CheckClarityContactsInSupr(Action):
                 if not (account_missing or multiple_accounts):
                     continue
                 name = project.udf.get("Name of {}".format(role)) or "Name missing from LIMS"
-                email_body += "{} {} SUPR {}<br><hr>".format(role, "missing from" if account_missing else "has multiple accounts in", "( {}, {} )".format(name, email))
+                email_body += "{}: {} {} SUPR {}<br>".format(project.name, role, "missing from" if account_missing else "has multiple accounts in", "( {}, {} )".format(name, email))
 
         return (True, email_body)
 

--- a/actions/check_clarity_contacts_in_supr.py
+++ b/actions/check_clarity_contacts_in_supr.py
@@ -53,12 +53,14 @@ class CheckClarityContactsInSupr(Action):
         for project in projects:
             roles = ["PI", "bioinformatics responsible person"]
             for role in roles:
-                email = project.udf.get("Email of {}".format(role)) or continue
+                email = project.udf.get("Email of {}".format(role))
+                if not email:
+                    continue
                 (account_missing, multiple_accounts) = self.check_email_in_supr(email.strip())
-                if not account_missing or multiple_accounts:
+                if not (account_missing or multiple_accounts):
                     continue
                 name = project.udf.get("Name of {}".format(role)) or "Name missing from LIMS"
-                email_body += "{} {} SUPR {}<br>".format(role, "missing from" if account_missing else "has multiple accounts in", "( {}, {} )".format(name, email))
+                email_body += "{} {} SUPR {}<br><hr>".format(role, "missing from" if account_missing else "has multiple accounts in", "( {}, {} )".format(name, email))
 
         return (True, email_body)
 

--- a/actions/check_clarity_contacts_in_supr.yaml
+++ b/actions/check_clarity_contacts_in_supr.yaml
@@ -6,8 +6,19 @@ enabled: true
 entry_point: "check_clarity_contacts_in_supr.py"
 
 #parameters:
-#  flowcell_name:
+#  supr_api_url:
 #    type: "string"
-#    description: "Name of the flowcell used to look up the samplesheet in the Clarity LIMS"
+#    description: "Base URL of the SUPR API"
 #    required: true
+
+#  supr_api_user:
+#   type: "string"
+#   description: "Username for the SUPR API"
+#   required: true
+
+#  supr_api_key:
+#    type: "string"
+#    desription: "Password for the SUPR API"
+#    required: true
+#    secret: true
 

--- a/actions/check_clarity_contacts_in_supr.yaml
+++ b/actions/check_clarity_contacts_in_supr.yaml
@@ -1,0 +1,13 @@
+---
+name: "check_clarity_contacts_in_supr"
+runner_type: "python-script"
+description: "Looks up project contacts in Clarity LIMS and checks that SUPR accounts are present for their emails"
+enabled: true
+entry_point: "check_clarity_contacts_in_supr.py"
+
+#parameters:
+#  flowcell_name:
+#    type: "string"
+#    description: "Name of the flowcell used to look up the samplesheet in the Clarity LIMS"
+#    required: true
+

--- a/actions/check_clarity_contacts_in_supr.yaml
+++ b/actions/check_clarity_contacts_in_supr.yaml
@@ -5,20 +5,20 @@ description: "Looks up project contacts in Clarity LIMS and checks that SUPR acc
 enabled: true
 entry_point: "check_clarity_contacts_in_supr.py"
 
-#parameters:
-#  supr_api_url:
-#    type: "string"
-#    description: "Base URL of the SUPR API"
-#    required: true
+parameters:
+  supr_api_url:
+    type: "string"
+    description: "Base URL of the SUPR API"
+    required: true
 
-#  supr_api_user:
-#   type: "string"
-#   description: "Username for the SUPR API"
-#   required: true
+  supr_api_user:
+   type: "string"
+   description: "Username for the SUPR API"
+   required: true
 
-#  supr_api_key:
-#    type: "string"
-#    desription: "Password for the SUPR API"
-#    required: true
-#    secret: true
+  supr_api_key:
+    type: "string"
+    desription: "Password for the SUPR API"
+    required: true
+    secret: true
 

--- a/actions/check_clarity_contacts_in_supr.yaml
+++ b/actions/check_clarity_contacts_in_supr.yaml
@@ -18,7 +18,7 @@ parameters:
 
   supr_api_key:
     type: "string"
-    desription: "Password for the SUPR API"
+    description: "Password for the SUPR API"
     required: true
     secret: true
 

--- a/actions/check_clarity_contacts_in_supr_workflow.yaml
+++ b/actions/check_clarity_contacts_in_supr_workflow.yaml
@@ -1,0 +1,16 @@
+---
+name: check_clarity_contacts_in_supr_workflow 
+description: Check if ClarityLIMS contacts have SUPR accounts, and email if not
+enabled: true
+runner_type: mistral-v2
+entry_point: workflows/check_clarity_contacts_in_supr_workflow.yaml
+pack: snpseq_packs
+parameters:
+  context:
+    default: {}
+    immutable: true
+    type: object
+  workflow:
+    default: snpseq_packs.check_clarity_contacts_in_supr_workflow
+    immutable: true
+    type: string

--- a/actions/lib/supr_utils.py
+++ b/actions/lib/supr_utils.py
@@ -1,0 +1,113 @@
+import requests
+import json
+import math
+from datetime import date
+from dateutil.relativedelta import relativedelta
+
+# Needs to be run in a Stackstorm virtualenv
+from st2actions.runners.pythonrunner import Action
+
+
+class SuprUtils:
+
+    DATE_FORMAT = '%Y-%m-%d'
+
+    @staticmethod
+    def search_by_email(base_url, email, user, key):
+        search_person_url = '{}/person/search/'.format(base_url)
+        # Search case insensitive
+        params = {'email_i': email}
+        response = requests.get(search_person_url, params=params, auth=(user, key))
+
+        if response.status_code != 200:
+            raise AssertionError("Status code returned when trying to get PI id for email: "
+                                 "{} was not 200. Response was: {}".format(email, response.content))
+
+        response_as_json = json.loads(response.content)
+        matches = response_as_json["matches"]
+
+        if len(matches) < 1:
+            raise AssertionError("There were no hits in SUPR for email: {}".format(email))
+
+        if len(matches) > 1:
+            raise AssertionError("There we more than one hit in SUPR for email: {}".format(email))
+
+        return matches[0]["id"]
+
+    @staticmethod
+    def search_by_emails(base_url, emails, user, key):
+        return map(lambda email: SuprUtils.search_by_email(base_url=base_url, email=email, user=user, key=key), emails)
+
+    @staticmethod
+    def search_for_pi_and_members(project_to_email_dict, supr_base_api_url, api_user, api_key):
+        res = {}
+        for project, project_info in project_to_email_dict.iteritems():
+            res[project] = {"pi_id": SuprUtils.search_by_email(
+                base_url=supr_base_api_url, email=project_info['email'], user=api_user, key=api_key),
+                            "member_ids": SuprUtils.search_by_emails(
+                base_url=supr_base_api_url, emails=project_info['members'], user=api_user, key=api_key)}
+        return res
+
+    @staticmethod
+    def create_delivery_project(base_url, project_names_and_ids, staging_info, project_info, user, key):
+
+        result = {}
+        for ngi_project_name in staging_info.keys():
+            pi_id = project_names_and_ids[ngi_project_name]['pi_id']
+            member_ids = project_names_and_ids[ngi_project_name]['member_ids']
+
+            create_delivery_project_url = '{}/ngi_delivery/project/create/'.format(base_url)
+
+            today = date.today()
+            today_formatted = today.strftime(SuprUtils.DATE_FORMAT)
+            three_months_from_now = today + relativedelta(months=+3)
+            three_months_from_now_formatted = three_months_from_now.strftime(SuprUtils.DATE_FORMAT)
+
+            # Check smallest of delivery size in bytes and one gb (api wants size passed in giga bytes)
+            size_of_delivery = max(1, math.ceil(staging_info[ngi_project_name]['size']/pow(10, 9)))
+
+            payload = {
+                'ngi_project_name': ngi_project_name,
+                'title': "DELIVERY_{}_{}".format(ngi_project_name, today_formatted),
+                'pi_id': pi_id,
+                'member_ids': member_ids,
+                'start_date': today_formatted,
+                'end_date': three_months_from_now_formatted,
+                'continuation_name': '',
+                'allocated': size_of_delivery,
+                'api_opaque_data': '',
+                'ngi_ready': False,
+                'ngi_delivery_status': '',
+                'ngi_sensitive_data': project_info[ngi_project_name]['sensitive']
+            }
+
+            response = requests.post(create_delivery_project_url,
+                                     data=json.dumps(payload),
+                                     auth=(user, key))
+
+            if response.status_code != 200:
+                raise AssertionError("Status code returned when trying to create delivery "
+                                     "project was not 200. Response was: {}".format(response.content))
+
+            result[ngi_project_name] = json.loads(response.content)
+
+        return result
+
+
+    @staticmethod
+    def check_ngi_ready_status(supr_base_api_url, api_user, api_key, project):
+        project_id = project['id']
+        project_url = '{}/project/{}/'.format(supr_base_api_url, project_id)
+        response = requests.get(project_url, auth=(api_user, api_key))
+        response_as_json = json.loads(response.content)
+        ngi_ready = response_as_json['ngi_ready']
+
+        output_object = {project['ngi_project_name']: response_as_json['ngi_ready']}
+
+        if ngi_ready:
+            return True, output_object
+        else:
+            return False, output_object
+
+
+

--- a/actions/lib/supr_utils.py
+++ b/actions/lib/supr_utils.py
@@ -4,10 +4,6 @@ import math
 from datetime import date
 from dateutil.relativedelta import relativedelta
 
-# Needs to be run in a Stackstorm virtualenv
-from st2actions.runners.pythonrunner import Action
-
-
 class SuprUtils:
 
     DATE_FORMAT = '%Y-%m-%d'

--- a/actions/supr.py
+++ b/actions/supr.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 
-import requests
-import json
-import math
-from datetime import date
-from dateutil.relativedelta import relativedelta
+from lib.supr_utils import *
 
 # Needs to be run in a Stackstorm virtualenv
 from st2actions.runners.pythonrunner import Action
@@ -12,115 +8,17 @@ from st2actions.runners.pythonrunner import Action
 
 class Supr(Action):
 
-    DATE_FORMAT = '%Y-%m-%d'
-
-    @staticmethod
-    def search_by_email(base_url, email, user, key):
-        search_person_url = '{}/person/search/'.format(base_url)
-        # Search case insensitive
-        params = {'email_i': email}
-        response = requests.get(search_person_url, params=params, auth=(user, key))
-
-        if response.status_code != 200:
-            raise AssertionError("Status code returned when trying to get PI id for email: "
-                                 "{} was not 200. Response was: {}".format(email, response.content))
-
-        response_as_json = json.loads(response.content)
-        matches = response_as_json["matches"]
-
-        if len(matches) < 1:
-            raise AssertionError("There were no hits in SUPR for email: {}".format(email))
-
-        if len(matches) > 1:
-            raise AssertionError("There we more than one hit in SUPR for email: {}".format(email))
-
-        return matches[0]["id"]
-
-    @staticmethod
-    def search_by_emails(base_url, emails, user, key):
-        return map(lambda email: Supr.search_by_email(base_url=base_url, email=email, user=user, key=key), emails)
-
-    @staticmethod
-    def search_for_pi_and_members(project_to_email_dict, supr_base_api_url, api_user, api_key):
-        res = {}
-        for project, project_info in project_to_email_dict.iteritems():
-            res[project] = {"pi_id": Supr.search_by_email(
-                base_url=supr_base_api_url, email=project_info['email'], user=api_user, key=api_key),
-                            "member_ids": Supr.search_by_emails(
-                base_url=supr_base_api_url, emails=project_info['members'], user=api_user, key=api_key)}
-        return res
-
-    @staticmethod
-    def create_delivery_project(base_url, project_names_and_ids, staging_info, project_info, user, key):
-
-        result = {}
-        for ngi_project_name in staging_info.keys():
-            pi_id = project_names_and_ids[ngi_project_name]['pi_id']
-            member_ids = project_names_and_ids[ngi_project_name]['member_ids']
-
-            create_delivery_project_url = '{}/ngi_delivery/project/create/'.format(base_url)
-
-            today = date.today()
-            today_formatted = today.strftime(Supr.DATE_FORMAT)
-            three_months_from_now = today + relativedelta(months=+3)
-            three_months_from_now_formatted = three_months_from_now.strftime(Supr.DATE_FORMAT)
-
-            # Check smallest of delivery size in bytes and one gb (api wants size passed in giga bytes)
-            size_of_delivery = max(1, math.ceil(staging_info[ngi_project_name]['size']/pow(10, 9)))
-
-            payload = {
-                'ngi_project_name': ngi_project_name,
-                'title': "DELIVERY_{}_{}".format(ngi_project_name, today_formatted),
-                'pi_id': pi_id,
-                'member_ids': member_ids,
-                'start_date': today_formatted,
-                'end_date': three_months_from_now_formatted,
-                'continuation_name': '',
-                'allocated': size_of_delivery,
-                'api_opaque_data': '',
-                'ngi_ready': False,
-                'ngi_delivery_status': '',
-                'ngi_sensitive_data': project_info[ngi_project_name]['sensitive']
-            }
-
-            response = requests.post(create_delivery_project_url,
-                                     data=json.dumps(payload),
-                                     auth=(user, key))
-
-            if response.status_code != 200:
-                raise AssertionError("Status code returned when trying to create delivery "
-                                     "project was not 200. Response was: {}".format(response.content))
-
-            result[ngi_project_name] = json.loads(response.content)
-
-        return result
-
-    @staticmethod
-    def check_ngi_ready_status(supr_base_api_url, api_user, api_key, project):
-        project_id = project['id']
-        project_url = '{}/project/{}/'.format(supr_base_api_url, project_id)
-        response = requests.get(project_url, auth=(api_user, api_key))
-        response_as_json = json.loads(response.content)
-        ngi_ready = response_as_json['ngi_ready']
-
-        output_object = {project['ngi_project_name']: response_as_json['ngi_ready']}
-
-        if ngi_ready:
-            return True, output_object
-        else:
-            return False, output_object
-
     def run(self, action, supr_base_api_url, api_user, api_key, **kwargs):
         if action == "get_id_from_email":
-            return self.search_for_pi_and_members(kwargs['project_to_email_sensitive_dict'], supr_base_api_url, api_user, api_key)
+            return SuprUtils.search_for_pi_and_members(kwargs['project_to_email_sensitive_dict'], supr_base_api_url, api_user, api_key)
         elif action == 'create_delivery_project':
-            return self.create_delivery_project(supr_base_api_url,
+            return SuprUtils.create_delivery_project(supr_base_api_url,
                                                 kwargs['project_names_and_ids'],
                                                 kwargs['staging_info'],
                                                 kwargs['project_info'],
                                                 api_user, api_key)
         elif action == 'check_ngi_ready':
-            return self.check_ngi_ready_status(supr_base_api_url, api_user, api_key, kwargs['project'])
+            return SuprUtils.check_ngi_ready_status(supr_base_api_url, api_user, api_key, kwargs['project'])
         else:
             raise AssertionError("Action: {} was not recognized.".format(action))
 

--- a/actions/workflows/check_clarity_contacts_in_supr_workflow.yaml
+++ b/actions/workflows/check_clarity_contacts_in_supr_workflow.yaml
@@ -31,9 +31,9 @@ workflows:
       check_clarity_contacts_in_supr:
         action: snpseq_packs.check_clarity_contacts_in_supr
         input:
+          supr_api_url: <% $.supr_api_url %>
           supr_api_user: <% $.supr_api_user %>
           supr_api_key: <% $.supr_api_key %>
-          supr_base_api_url: <% $.supr_api_url %>
         publish:
           missing_in_supr_email: <% task(check_clarity_contacts_in_supr).result.result %>
         on-success:
@@ -51,7 +51,7 @@ workflows:
       email_supr_account_report_bio:
         action: core.sendmail
         input: 
-          to: <% $.end_mail_to %> 
+          to: <% $.send_mail_to %> 
           subject: "[SUPR report] - Project contacts without SUPR accounts"
           body: <% $.missing_in_supr_email %>
 

--- a/actions/workflows/check_clarity_contacts_in_supr_workflow.yaml
+++ b/actions/workflows/check_clarity_contacts_in_supr_workflow.yaml
@@ -1,0 +1,57 @@
+---
+version: "2.0" # mistral version
+name: snpseq_packs.check_clarity_contacts_in_supr_workflow
+description: Retrieves open projects from ClarityLIMS, checks PI and bioinformatician emails in SUPR for accounts then emails project coordinators/bio with missing accounts.
+
+workflows:
+  main:
+    type: direct
+    tasks:
+
+      note_workflow_version:
+        action: core.local
+        input:
+          cmd: git rev-parse HEAD
+          cwd: /opt/stackstorm/packs/snpseq_packs/
+        on-success:
+          - get_config
+
+      get_config:
+        action: snpseq_packs.get_pack_config
+        publish:
+          supr_api_user: <% task(get_config).result.result.supr_api_user %>
+          supr_api_key: <% task(get_config).result.result.supr_api_key %>
+          supr_api_url: <% task(get_config).result.result.supr_api_url %>
+          project_coordinator_email_adress: <% task(get_config).result.result.project_coordinator_email_adress %>
+          bio_email_adress: <% task(get_config).result.result.send_mail_to %>
+          delivery_workflow_status_slack_channel: <% task(get_config).result.result.delivery_workflow_status_slack_channel %>
+        on-success:
+          - check_clarity_contacts_in_supr
+
+      check_clarity_contacts_in_supr:
+        action: snpseq_packs.check_clarity_contacts_in_supr
+        input:
+          supr_api_user: <% $.supr_api_user %>
+          supr_api_key: <% $.supr_api_key %>
+          supr_base_api_url: <% $.supr_api_url %>
+        publish:
+          missing_in_supr_email: <% task(check_clarity_contacts_in_supr).result.result %>
+        on-success:
+          - email_supr_account_report_project_coord
+          - email_supr_account_report_bio
+            #TODO: Add slack notification as well
+
+      email_supr_account_report_project_coord:
+        action: core.sendmail
+        input: 
+          to: <% $.project_coordinator_email_adress %> 
+          subject: "[SUPR report] - Project contacts without SUPR accounts"
+          body: <% $.missing_in_supr_email %>
+
+      email_supr_account_report_bio:
+        action: core.sendmail
+        input: 
+          to: <% $.end_mail_to %> 
+          subject: "[SUPR report] - Project contacts without SUPR accounts"
+          body: <% $.missing_in_supr_email %>
+

--- a/actions/workflows/check_clarity_contacts_in_supr_workflow.yaml
+++ b/actions/workflows/check_clarity_contacts_in_supr_workflow.yaml
@@ -37,8 +37,8 @@ workflows:
         publish:
           missing_in_supr_email: <% task(check_clarity_contacts_in_supr).result.result %>
         on-success:
-          - email_supr_account_report_project_coord
-          - email_supr_account_report_bio
+          - email_supr_account_report_project_coord: <% $.missing_in_supr_email != '' %>
+          - email_supr_account_report_bio: <% $.missing_in_supr_email != '' %>
 
       email_supr_account_report_project_coord:
         action: core.sendmail

--- a/actions/workflows/check_clarity_contacts_in_supr_workflow.yaml
+++ b/actions/workflows/check_clarity_contacts_in_supr_workflow.yaml
@@ -23,7 +23,7 @@ workflows:
           supr_api_key: <% task(get_config).result.result.supr_api_key %>
           supr_api_url: <% task(get_config).result.result.supr_api_url %>
           project_coordinator_email_adress: <% task(get_config).result.result.project_coordinator_email_adress %>
-          bio_email_adress: <% task(get_config).result.result.send_mail_to %>
+          send_mail_to: <% task(get_config).result.result.send_mail_to %>
           delivery_workflow_status_slack_channel: <% task(get_config).result.result.delivery_workflow_status_slack_channel %>
         on-success:
           - check_clarity_contacts_in_supr

--- a/actions/workflows/check_clarity_contacts_in_supr_workflow.yaml
+++ b/actions/workflows/check_clarity_contacts_in_supr_workflow.yaml
@@ -39,7 +39,6 @@ workflows:
         on-success:
           - email_supr_account_report_project_coord
           - email_supr_account_report_bio
-            #TODO: Add slack notification as well
 
       email_supr_account_report_project_coord:
         action: core.sendmail

--- a/rules/check_clarity_contacts.yaml
+++ b/rules/check_clarity_contacts.yaml
@@ -1,0 +1,19 @@
+---
+name: "snpseq_packs.check_clarity_contacts"
+pack: "snpseq_packs"
+description: "Checks ClarityLIMS project contacts for SUPR accounts, emails project coordinators and BIO if not present"
+enabled: true
+
+trigger:
+    type: "core.st2.CronTimer"
+    parameters:
+      timezone: "UTC"
+      day_of_week: "mon"
+      hour: 6
+      minute: 0
+      second: 0
+
+action:
+  ref: "snpseq_packs.check_clarity_contacts_in_supr_workflow"
+
+

--- a/tests/test_supr.py
+++ b/tests/test_supr.py
@@ -1,12 +1,14 @@
 import mock
 import json
 
-import supr
+import lib.supr_utils
+
 from st2tests.base import BaseActionTestCase
 
 
 class SuprTestCase(BaseActionTestCase):
-    action_cls = supr.Supr
+    #action_cls = supr.Supr
+    action_cls = lib.supr_utils.SuprUtils
 
     class MockPostResponse:
         def __init__(self, content, status_code=200):
@@ -49,7 +51,7 @@ class SuprTestCase(BaseActionTestCase):
         staging_info = {proj: {"size": 1e12} for proj in self.project_to_email_dict.keys()}
         project_info = dict(self.project_to_email_dict)
         return [
-            supr.Supr.create_delivery_project(
+            lib.supr_utils.SuprUtils.create_delivery_project(
                 self.supr_base_url, project_names_and_ids, staging_info, project_info, self.api_user, self.api_key),
             project_names_and_ids,
             staging_info,
@@ -57,7 +59,7 @@ class SuprTestCase(BaseActionTestCase):
 
     def test_create_delivery_project(self):
         with mock.patch.object(
-            supr.requests,
+            lib.supr_utils.requests,
             'post',
             side_effect=SuprTestCase.post_mock_reponse
         ) as post_mock:
@@ -72,7 +74,7 @@ class SuprTestCase(BaseActionTestCase):
 
     def test_create_delivery_project_fail(self):
         with mock.patch.object(
-            supr.requests,
+            lib.supr_utils.requests,
             'post',
             return_value=SuprTestCase.MockPostResponse("some fail content", status_code=400)
         ) as post_mock:
@@ -81,8 +83,8 @@ class SuprTestCase(BaseActionTestCase):
 
     def test_search_for_pis(self):
         with mock.patch.object(
-                supr.Supr, "search_by_email", side_effect=SuprTestCase.mock_pi_id) as search_mock:
-            observed_ids = supr.Supr.search_for_pi_and_members(
+                lib.supr_utils.SuprUtils, "search_by_email", side_effect=SuprTestCase.mock_pi_id) as search_mock:
+            observed_ids = lib.supr_utils.SuprUtils.search_for_pi_and_members(
                 self.project_to_email_dict,
                 self.supr_base_url,
                 self.api_user,


### PR DESCRIPTION
**What problems does this PR solve?**
- This PR contains a workflow for checking that ClarityLIMS project contacts have a SUPR account, if not, emails are sent to BIO and project coordinators. The workflow runs as a cron job 6 in the morning every monday.

- Static functions for communication with SUPR are moved from actions/supr.py to actions/lib/supr_utils.py to make them reusable on an python level as well as stackstorm.

**How has the changes been tested?**
The contact action and workflows have been tested on vagrant box and mm-xart001, additionally a delivery workflow was used to test the function of the supr.py action after breaking out the static functions to /lib.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
