### PR TITLE
Rename arteria-bcl2fastq additional arguments

### DIFF
--- a/actions/parse_bcl2fastq_args.yaml
+++ b/actions/parse_bcl2fastq_args.yaml
@@ -30,7 +30,7 @@ parameters:
     type: string
     description: "Base mask to use (see bcl2fastq manual for detailed description)."
 
-  additional_arguments:
+  additional_args:
     default: ""
     type: string
     description: "Any additional arguments to bcl2fastq can be fed here. Note that quoutes (\") are needed around arguments for the to parse properly. E.g. \"--my-first-arg 1 --my-second-arg 2\" "

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -160,7 +160,7 @@ workflows:
                     barcode_mismatches: "<% $.barcode_mismatches %>"
                     tiles: "<% $.tiles %>"
                     use_base_mask: "<% $.use_base_mask %>"
-                    additional_arguments: "<% $.bcl2fastq_additional_arguments %>"
+                    additional_args: "<% $.bcl2fastq_additional_arguments %>"
                     create_indexes: "True"
                 publish:
                     bcl2fastq_body: <% task(construct_bcl2fastq_body).result.result %>


### PR DESCRIPTION
**What problems does this PR solve?**
When performing some testing I discovered that the additional arguments that I sent to arteria-bcl2fastq was ignored by the service. When looking into it I discovered that arteria-bcl2fastq expects `additional_args` and not `additional_arguments`. 
https://github.com/arteria-project/arteria-bcl2fastq/blob/f14678315c4a9dd6572e9e28361812209e832d8b/bcl2fastq/handlers/bcl2fastq_handlers.py#L142

In this PR the parameter is renamed to correspond to what arteria-bcl2fastq expects.

**How has the changes been tested?**
Tested in vagrant environment.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
