### PR TITLE
Art 48 remove runfolders

### DIFF
--- a/actions/lib/purge_remote_folder.py
+++ b/actions/lib/purge_remote_folder.py
@@ -1,0 +1,127 @@
+#!/usr/bin/python
+
+import argparse
+import datetime
+import json
+import logging
+import os
+import shutil
+import socket
+
+
+class PurgeRemoteFolders(object):
+
+    def __init__(self, biotank_archive_folder, age_in_days, dryrun):
+        self.biotank_archive_folder = str(biotank_archive_folder)
+        self.age_in_days = int(age_in_days)
+        self.dryrun = bool(dryrun)
+
+        hostname = socket.gethostname()
+        self.directory = self.sanitize_path(
+            self.biotank_archive_folder,
+            os.path.join(
+                "/data",
+                hostname))
+        self.logfile = os.path.join(self.directory, "KEEP_removed_archives.log")
+
+    @staticmethod
+    def sanitize_path(dirty_path, directory):
+        if os.path.isabs(dirty_path):
+            raise ValueError(
+                "{p} is an absolute path which is not allowed at this point".format(
+                    p=dirty_path))
+        # fully resolve path to make sure that no symlinks or upward references are left and cause surprises
+        clean_path = os.path.realpath(
+            os.path.join(directory, dirty_path))
+        # ensure that the resulting path is below the directory
+        if not clean_path.startswith(directory):
+            raise ValueError(
+                "{p} appears to resolve to a path outside of {d} which is not allowed at this point".format(
+                    p=dirty_path, d=directory))
+        return clean_path
+
+    def get_files_and_folders(self):
+        older_than = datetime.date.today() - datetime.timedelta(days=self.age_in_days)
+
+        def _path_should_be_purged(p):
+            return datetime.date.fromtimestamp(
+                os.stat(
+                    os.path.join(
+                        self.directory, p)).st_mtime) < older_than and not p.startswith("KEEP")
+
+        return filter(
+            _path_should_be_purged,
+            os.listdir(self.directory))
+
+    def purge_files_and_folders(self, files_and_folders_to_purge, logger):
+
+        def _purge_path(p):
+            purge_fn = shutil.rmtree if os.path.isdir(p) else os.unlink
+            if not self.dryrun:
+                purge_fn(p)
+                logger.info(p)
+
+        map(
+            _purge_path,
+            map(
+                lambda p: self.sanitize_path(p, self.directory),
+                files_and_folders_to_purge))
+
+    def purge(self, logger):
+
+        try:
+            files_and_folders_to_purge = self.get_files_and_folders()
+        except Exception as e:
+            print(
+                "encountered the following error when trying to determine files and folders to purge: {msg}".format(msg=e))
+            raise
+
+        try:
+            self.purge_files_and_folders(files_and_folders_to_purge, logger)
+        except Exception as e:
+            print(
+                "encountered the following error when trying to purge files and folders: {msg}".format(msg=e))
+            raise
+
+        return files_and_folders_to_purge
+
+
+def main():
+
+    parser = argparse.ArgumentParser(
+        description="Purge archived runfolders from biotanks based on age")
+
+    # Required arguments
+    parser.add_argument(
+        "--biotank_archive_folder",
+        required=True,
+        help="Path to the folder for archived runfolders, relative to the host-specific data path")
+    parser.add_argument(
+        "--age_in_days",
+        required=True,
+        help="Files and folders that haven't been modified in this many days will be removed")
+    parser.add_argument(
+        "--dryrun",
+        required=False,
+        action="store_true",
+        help="If true, only a dry-run will be performed and nothing is removed")
+    parser.set_defaults(dryrun=False)
+    args = parser.parse_args()
+
+    cleaner = PurgeRemoteFolders(args.biotank_archive_folder, args.age_in_days, args.dryrun)
+
+    execution_id = os.environ.get("ST2_ACTION_EXECUTION_ID", "")
+    # create logger
+    logger = logging.getLogger("purge_remote_folder")
+    logger.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(message)s,%(asctime)s,{id}'.format(id=execution_id))
+    ch = logging.FileHandler(cleaner.logfile, delay=True)
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+    result_as_json = cleaner.purge(logger)
+    print(json.dumps(result_as_json))
+
+
+if __name__ == '__main__':
+    main()

--- a/actions/lib/purge_remote_folder.py
+++ b/actions/lib/purge_remote_folder.py
@@ -11,18 +11,45 @@ import socket
 
 class PurgeRemoteFolders(object):
 
-    def __init__(self, biotank_archive_folder, age_in_days, dryrun):
+    def __init__(self, biotank_archive_folder, age_in_days, dryrun, execution_id):
+        # do some explicit sanity checking here
+        if not biotank_archive_folder:
+            raise ValueError(
+                "an illegal value for biotank_archive_folder was specified: {val}".format(val=biotank_archive_folder))
+        if int(age_in_days) <= 0:
+            raise ValueError(
+                "an illegal value for age_in_days was specified: {val}".format(val=age_in_days))
+
         self.biotank_archive_folder = str(biotank_archive_folder)
         self.age_in_days = int(age_in_days)
         self.dryrun = bool(dryrun)
 
+        # the directory to look for things to clean are constructed from e.g. the hostname of the machine
+        # as a precaution, this is hardcoded here and can not be supplied as a parameter
         hostname = socket.gethostname()
-        self.directory = self.sanitize_path(
+        self.archive_base_dir = self.sanitize_path(
             self.biotank_archive_folder,
             os.path.join(
                 "/data",
                 hostname))
-        self.logfile = os.path.join(self.directory, "KEEP_removed_archives.log")
+        self.log = self.setup_logger(execution_id)
+
+    def setup_logger(self, execution_id):
+
+        # setup a formatter that will include the st2 execution id with the log
+        formatter = logging.Formatter('%(message)s,%(asctime)s,{id}'.format(id=execution_id))
+
+        # the logfile will be written in the folder where the cleanup is taking place, the "KEEP" prefix will keep it
+        # from being removed
+        logfile = os.path.join(self.archive_base_dir, "KEEP_removed_archives.log")
+        ch = logging.FileHandler(logfile, delay=True)
+        ch.setFormatter(formatter)
+
+        logger = logging.getLogger(__name__)
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(ch)
+
+        return logger
 
     @staticmethod
     def sanitize_path(dirty_path, directory):
@@ -41,46 +68,43 @@ class PurgeRemoteFolders(object):
         return clean_path
 
     def get_files_and_folders(self):
-        older_than = datetime.date.today() - datetime.timedelta(days=self.age_in_days)
+        remove_if_modified_before_this = datetime.date.today() - datetime.timedelta(days=self.age_in_days)
 
         def _path_should_be_purged(p):
-            return datetime.date.fromtimestamp(
-                os.stat(
-                    os.path.join(
-                        self.directory, p)).st_mtime) < older_than and not p.startswith("KEEP")
+            path_modtimestamp = os.stat(os.path.join(self.archive_base_dir, p)).st_mtime
+            path_modification_date = datetime.date.fromtimestamp(path_modtimestamp)
+            return path_modification_date < remove_if_modified_before_this and not p.startswith("KEEP")
 
         return filter(
             _path_should_be_purged,
-            os.listdir(self.directory))
+            os.listdir(self.archive_base_dir))
 
-    def purge_files_and_folders(self, files_and_folders_to_purge, logger):
+    def purge_files_and_folders(self, files_and_folders_to_purge):
 
-        def _purge_path(p):
-            purge_fn = shutil.rmtree if os.path.isdir(p) else os.unlink
+        for file_or_folder_to_purge in files_and_folders_to_purge:
+            sanitized_path = self.sanitize_path(file_or_folder_to_purge, self.archive_base_dir)
+            # use shutil.rmtree for directories and os.unlink for everything else
+            purge_fn = shutil.rmtree if os.path.isdir(sanitized_path) else os.unlink
             if not self.dryrun:
-                purge_fn(p)
-                logger.info(p)
+                purge_fn(sanitized_path)
+                self.log.info(sanitized_path)
 
-        map(
-            _purge_path,
-            map(
-                lambda p: self.sanitize_path(p, self.directory),
-                files_and_folders_to_purge))
-
-    def purge(self, logger):
+    def purge(self):
 
         try:
             files_and_folders_to_purge = self.get_files_and_folders()
         except Exception as e:
-            print(
-                "encountered the following error when trying to determine files and folders to purge: {msg}".format(msg=e))
+            self.log.error(
+                "encountered the following error when trying to determine files and folders to purge: {msg}".format(
+                    msg=e))
             raise
 
         try:
-            self.purge_files_and_folders(files_and_folders_to_purge, logger)
+            self.purge_files_and_folders(files_and_folders_to_purge)
         except Exception as e:
-            print(
-                "encountered the following error when trying to purge files and folders: {msg}".format(msg=e))
+            self.log.error(
+                "encountered the following error when trying to purge files and folders: {msg}".format(
+                    msg=e))
             raise
 
         return files_and_folders_to_purge
@@ -108,18 +132,10 @@ def main():
     parser.set_defaults(dryrun=False)
     args = parser.parse_args()
 
-    cleaner = PurgeRemoteFolders(args.biotank_archive_folder, args.age_in_days, args.dryrun)
-
     execution_id = os.environ.get("ST2_ACTION_EXECUTION_ID", "")
-    # create logger
-    logger = logging.getLogger("purge_remote_folder")
-    logger.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%(message)s,%(asctime)s,{id}'.format(id=execution_id))
-    ch = logging.FileHandler(cleaner.logfile, delay=True)
-    ch.setFormatter(formatter)
-    logger.addHandler(ch)
+    cleaner = PurgeRemoteFolders(args.biotank_archive_folder, args.age_in_days, args.dryrun, execution_id)
 
-    result_as_json = cleaner.purge(logger)
+    result_as_json = cleaner.purge()
     print(json.dumps(result_as_json))
 
 

--- a/actions/purge_archived_biotank_folders_workflow.yaml
+++ b/actions/purge_archived_biotank_folders_workflow.yaml
@@ -1,0 +1,25 @@
+---
+name: purge_archived_biotank_folders_workflow
+description: >
+  Permanently removes folders older than a comfigured age from the designated archive folder on the biotanks
+enabled: true
+runner_type: mistral-v2
+entry_point: workflows/purge_archived_biotank_folders_workflow.yaml
+pack: snpseq_packs
+parameters:
+  context:
+    default: {}
+    immutable: true
+    type: object
+  workflow:
+    default: snpseq_packs.purge_archived_biotank_folders_workflow
+    immutable: true
+    type: string
+  age_in_days:
+    default: 30
+    type: integer
+    description: "files and folders older than the specified number of days will be permanently removed from the configured location on the biotanks"
+  dryrun:
+    default: true
+    type: boolean
+    description: "DRY-RUN - only list folders to be purged by workflow"

--- a/actions/purge_archived_biotank_folders_workflow.yaml
+++ b/actions/purge_archived_biotank_folders_workflow.yaml
@@ -1,7 +1,7 @@
 ---
 name: purge_archived_biotank_folders_workflow
 description: >
-  Permanently removes folders older than a comfigured age from the designated archive folder on the biotanks
+  Permanently removes folders older than a configured age from the designated archive folder on the biotanks
 enabled: true
 runner_type: mistral-v2
 entry_point: workflows/purge_archived_biotank_folders_workflow.yaml

--- a/actions/purge_remote_folder.yaml
+++ b/actions/purge_remote_folder.yaml
@@ -1,0 +1,21 @@
+---
+name: purge_remote_folder
+description: Permanently removes files and folders older than the specified age from the configured archive folder
+enabled: true
+runner_type: remote-shell-script
+entry_point: lib/purge_remote_folder.py
+pack: snpseq_packs
+parameters:
+  biotank_archive_folder:
+    type: 'string'
+    required: true
+    description: Path to the folder for archived runfolders, relative to the host-specific data path
+  age_in_days:
+    type: 'integer'
+    description: Files and folders that haven't been modified in this many days will be removed
+    required: true
+  dryrun:
+    type: 'boolean'
+    description: If true, only a dry-run will be performed and nothing is removed
+    required: false
+    default: true

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -60,6 +60,7 @@ workflows:
                 irma_replace_expressions: <% task(get_config).result.result.irma_replace_expressions %>
                 remote_host_key: <% task(get_config).result.result.remote_host_key %>
                 biotank_user_key: <% task(get_config).result.result.biotank_user_key %>
+                biotank_archive_folder: <% task(get_config).result.result.biotank_archive_folder %>
                 samplesheet_fallback_path: <% task(get_config).result.result.samplesheet_fallback_path %>
               on-success:
                  - mark_as_started
@@ -331,26 +332,18 @@ workflows:
             remove_from_scratch:
               action: linux.rm
               input:
+                hosts: <% $.host %>
+                private_key: <% $.biotank_user_key %>
                 recursive: true
-                target: /data/scratch/< $.runfolder_name %>
-
-            get_runfolder_base_path:
-              action: core.local
-              input:
-                cmd: dirname "<% $.runfolder %>"
-              publish:
-                runfolder_base_path: "<% task(get_runfolder_base_path).result.stdout %>"
-              on-success:
-                - move_to_archived
+                target: /data/scratch/<% $.runfolder_name %>
 
             move_to_archived:
+              with-items: folder in <% list($.runfolder, concat($.runfolder, "_archive")) %>
               action: linux.mv
-              parameters:
+              input:
                 hosts: <% $.host %>
-                source:
-                  - <% $.runfolder %>
-                  - <% $.runfolder %>_archive
-                destination: <% $.runfolder_base_path %>/Arkiverade/
+                source: <% $.folder %>
+                destination: /data/<% $.host %>/<% $.biotank_archive_folder %>
                 private_key: <% $.biotank_user_key %>
 
             ## END CLEANUP ##
@@ -380,7 +373,7 @@ workflows:
                 method: "POST"
               on-success:
                 - remove_from_scratch
-                - get_runfolder_base_path
+                - move_to_archived
 
             mark_as_failed:
               action: core.http

--- a/actions/workflows/ngi_uu_workflow.yaml
+++ b/actions/workflows/ngi_uu_workflow.yaml
@@ -325,6 +325,36 @@ workflows:
             #    url: <% $.ngi_pipeline_url %>/<% $.runfolder_name %>
             ## END START NGI_PIPELINE ##
 
+            ## START CLEANUP ##
+
+            # this is a temporary workaround, the permanent fix is here: https://snpseq.atlassian.net/browse/ART-134
+            remove_from_scratch:
+              action: linux.rm
+              input:
+                recursive: true
+                target: /data/scratch/< $.runfolder_name %>
+
+            get_runfolder_base_path:
+              action: core.local
+              input:
+                cmd: dirname "<% $.runfolder %>"
+              publish:
+                runfolder_base_path: "<% task(get_runfolder_base_path).result.stdout %>"
+              on-success:
+                - move_to_archived
+
+            move_to_archived:
+              action: linux.mv
+              parameters:
+                hosts: <% $.host %>
+                source:
+                  - <% $.runfolder %>
+                  - <% $.runfolder %>_archive
+                destination: <% $.runfolder_base_path %>/Arkiverade/
+                private_key: <% $.biotank_user_key %>
+
+            ## END CLEANUP ##
+
             ## NOTIFIER START ###
             notify_finished:
                 action: core.sendmail
@@ -348,6 +378,9 @@ workflows:
                 url: http://<% $.host %>:<% $.runfolder_service_port %>/api/1.0/runfolders/path<% $.runfolder %>
                 body: '{"state": "done"}'
                 method: "POST"
+              on-success:
+                - remove_from_scratch
+                - get_runfolder_base_path
 
             mark_as_failed:
               action: core.http

--- a/actions/workflows/purge_archived_biotank_folders_workflow.yaml
+++ b/actions/workflows/purge_archived_biotank_folders_workflow.yaml
@@ -1,6 +1,6 @@
 version: "2.0" # mistral version
 name: snpseq_packs.purge_archived_biotank_folders_workflow
-description: The ngi workflow, from sequencer to remote system...
+description: Permanently removes folders older than a supplied age from the configured archive folder on the biotanks
 
 workflows:
     main:

--- a/actions/workflows/purge_archived_biotank_folders_workflow.yaml
+++ b/actions/workflows/purge_archived_biotank_folders_workflow.yaml
@@ -1,0 +1,77 @@
+version: "2.0" # mistral version
+name: snpseq_packs.purge_archived_biotank_folders_workflow
+description: The ngi workflow, from sequencer to remote system...
+
+workflows:
+    main:
+        type: direct
+        input:
+          - age_in_days
+          - dryrun
+        output:
+            output_the_whole_workflow_context: <% $ %>
+        task-defaults:
+            on-error:
+                - oh_shit_error
+
+        tasks:
+            ### GENERAL TASKS START ###
+            note_workflow_repo_version:
+              action: core.local
+              input:
+                cmd: git rev-parse HEAD
+                cwd: /opt/stackstorm/packs/snpseq_packs/
+              on-success:
+                - get_config
+
+            get_config:
+              action: snpseq_packs.get_pack_config
+              publish:
+                send_mail_to: <% task(get_config).result.result.send_mail_to %>
+                biotank_user_key: <% task(get_config).result.result.biotank_user_key %>
+                biotank_hosts: <% task(get_config).result.result.biotank_hosts %>
+                biotank_user: <% task(get_config).result.result.biotank_user %>
+                biotank_archive_folder: <% task(get_config).result.result.biotank_archive_folder %>
+                age_in_days: <% task(get_config).result.result.days_to_keep_archived_runfolder %>
+              on-success:
+                - purge_archived
+
+            purge_archived:
+              action: snpseq_packs.purge_remote_folder
+              input:
+                username: <% $.biotank_user %>
+                hosts: <% $.biotank_hosts %>
+                private_key: <% $.biotank_user_key %>
+                biotank_archive_folder: <% $.biotank_archive_folder %>
+                age_in_days: <% $.age_in_days %>
+                dryrun: <% $.dryrun %>
+              publish:
+                purged: <% task(purge_archived).result %>
+              on-success:
+                - message_body
+
+            message_body:
+              with-items: bt_host in <% $.purged.keys() %>
+              action: core.local
+              input:
+                cmd: echo "<% $.bt_host %>"; echo ""; echo "    <% $.purged.get($.bt_host, dict()).stdout.join("\n    ") %>"
+              publish:
+                message_body: <% task(message_body).result.select($.stdout).join("\n\n  ") %>
+              on-success:
+                - notify_finished
+
+            notify_finished:
+              action: core.sendmail
+              input:
+                to: <% $.send_mail_to %>
+                subject: "'[ARTERIA] - Removed archived runfolders'"
+                body: "Finished removing archived runfolders:<pre>\n  <% $.message_body %>\n</pre>"
+
+            oh_shit_error:
+                action: core.sendmail
+                input:
+                    to: <% $.send_mail_to %>
+                    subject: "'[ARTERIA] - OH SHIT ERROR occurred when purging the archive folders'"
+                    body: "An oh shit error occurred when purging the archive folders. Please investigate!"
+                on-complete:
+                  - fail

--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,10 @@ projman_connection_string: mssql+pymssql://<username>:<password>@<host>/<databas
 biotank_hosts: mm-xart002,mm-xart003
 biotank_user: arteria
 biotank_user_key: "/path/to/ssh/key"
+# the path to the archive folder, relative to the /data/biotankX/ folder
+biotank_archive_folder: relative/path/to/archive/folder
+days_to_keep_archived_runfolder: 30
+samplesheet_fallback_path: /path/to/samplesheet/fallback/location
 
 remote_host: testuppmax
 remote_user: arteria

--- a/rules/purge_archived_biotank_folders.yaml
+++ b/rules/purge_archived_biotank_folders.yaml
@@ -1,7 +1,7 @@
 ---
 name: "snpseq_packs.purge_archived_biotank_folders"
 pack: "snpseq_packs"
-description: "Permanently removes folders older than a comfigured age from the designated archive folder on the biotanks"
+description: "Permanently removes folders older than a configured age from the designated archive folder on the biotanks"
 enabled: true
 
 trigger:

--- a/rules/purge_archived_biotank_folders.yaml
+++ b/rules/purge_archived_biotank_folders.yaml
@@ -1,0 +1,19 @@
+---
+name: "snpseq_packs.purge_archived_biotank_folders"
+pack: "snpseq_packs"
+description: "Permanently removes folders older than a comfigured age from the designated archive folder on the biotanks"
+enabled: true
+
+trigger:
+    type: "core.st2.CronTimer"
+    parameters:
+      timezone: "UTC"
+      day_of_week: "sat"
+      hour: 15
+      minute: 0
+      second: 0
+
+action:
+    ref: "snpseq_packs.purge_archived_biotank_folders_workflow"
+    parameters:
+      dryrun: false

--- a/tests/test_purge_remote_folder.py
+++ b/tests/test_purge_remote_folder.py
@@ -29,9 +29,9 @@ class TestPurgeRemoteFolders(unittest.TestCase):
             mtime = atime if tfile.startswith("too_new") else \
                 self._to_unix_timestamp(datetime.date.today() - datetime.timedelta(days=(self.age_in_days + 1)))
             os.utime(os.path.join(self.directory, tfile), (atime, mtime))
-        self.action = PurgeRemoteFolders(os.path.basename(self.directory), self.age_in_days, self.dryrun)
-        self.action.directory = self.directory
         self.logger = mock.MagicMock(spec=logging.Logger)
+        self.action = PurgeRemoteFolders(os.path.basename(self.directory), self.age_in_days, self.dryrun, self.logger)
+        self.action.archive_base_dir = self.directory
 
     def tearDown(self):
         shutil.rmtree(self.directory, ignore_errors=True)
@@ -81,7 +81,7 @@ class TestPurgeRemoteFolders(unittest.TestCase):
         expected_directory = os.path.join("/data", socket.gethostname(), directory_pattern)
         expected_output = filter(lambda p: p.startswith("too_old"), self.files)
         self.action = PurgeRemoteFolders(directory_pattern, self.age_in_days, self.dryrun)
-        self.assertEqual(expected_directory, self.action.directory)
+        self.assertEqual(expected_directory, self.action.archive_base_dir)
         with mock.patch.object(
                 self.action, 'get_files_and_folders') as get_files_and_folders, mock.patch.object(
                 self.action, 'purge_files_and_folders') as purge_files_and_folders:

--- a/tests/test_purge_remote_folder.py
+++ b/tests/test_purge_remote_folder.py
@@ -1,0 +1,98 @@
+
+import datetime
+import logging
+import mock
+import os
+import shutil
+import socket
+import tempfile
+import unittest
+
+from lib.purge_remote_folder import PurgeRemoteFolders
+
+
+class TestPurgeRemoteFolders(unittest.TestCase):
+
+    @staticmethod
+    def _to_unix_timestamp(date_obj):
+        return (date_obj - datetime.date(1970, 1, 1)).total_seconds()
+
+    def setUp(self):
+        self.age_in_days = 30
+        self.dryrun = True
+        self.directory = tempfile.mkdtemp()
+        self.files = [
+            os.path.basename(tempfile.mkstemp(prefix=name, dir=self.directory)[1]) for name in [
+                "too_old", "too_new", "KEEP_"]]
+        for tfile in self.files:
+            atime = self._to_unix_timestamp(datetime.date.today())
+            mtime = atime if tfile.startswith("too_new") else \
+                self._to_unix_timestamp(datetime.date.today() - datetime.timedelta(days=(self.age_in_days + 1)))
+            os.utime(os.path.join(self.directory, tfile), (atime, mtime))
+        self.action = PurgeRemoteFolders(os.path.basename(self.directory), self.age_in_days, self.dryrun)
+        self.action.directory = self.directory
+        self.logger = mock.MagicMock(spec=logging.Logger)
+
+    def tearDown(self):
+        shutil.rmtree(self.directory, ignore_errors=True)
+
+    def test_sanitize_path(self):
+        root_dir = os.path.join("/path", "to", "root")
+        abs_path = os.path.join("/this", "is", "an", "absolute", "path")
+        escape_path = os.path.join("..", "some", "other", "dir")
+        upward_path = os.path.join("this", "..", "path", "..", "has", "..", "upward", "..", "references", "..")
+        good_path = os.path.join("and", "subdirectory")
+        self.assertRaisesRegexp(ValueError, "absolute path which", self.action.sanitize_path, abs_path, root_dir)
+        self.assertRaisesRegexp(ValueError, "path outside of", self.action.sanitize_path, escape_path, root_dir)
+        self.assertEqual(root_dir, self.action.sanitize_path(upward_path, root_dir))
+        self.assertEqual(os.path.join(root_dir, good_path), self.action.sanitize_path(good_path, root_dir))
+        # create symlinks that may escape from directory
+        abs_symlink = "abs_symlink"
+        escape_symlink = "escape_symlink"
+        good_symlink = "good_symlink"
+        os.symlink(abs_path, os.path.join(self.directory, abs_symlink))
+        os.symlink(escape_path, os.path.join(self.directory, escape_symlink))
+        os.symlink(os.path.join(self.directory, good_path), os.path.join(self.directory, good_symlink))
+        self.assertRaisesRegexp(
+            ValueError, "path outside of", self.action.sanitize_path, abs_symlink, self.directory)
+        self.assertRaisesRegexp(
+            ValueError, "path outside of", self.action.sanitize_path, escape_symlink, self.directory)
+        self.assertEqual(
+            os.path.join(self.directory, good_path), self.action.sanitize_path(good_symlink, self.directory))
+
+    def test_get_files_and_folders(self):
+        expected_files_and_folders = filter(
+            lambda p: os.path.basename(p).startswith("too_old"),
+            self.files)
+        observed_files_and_folders = self.action.get_files_and_folders()
+        self.assertListEqual(expected_files_and_folders, observed_files_and_folders)
+
+    def test_purge_files_and_folders(self):
+        self.action.purge_files_and_folders(self.files, self.logger)
+        self.assertTrue(all(map(lambda p: os.path.exists(os.path.join(self.directory, p)), self.files)))
+        self.action.dryrun = False
+        self.action.purge_files_and_folders(self.files, self.logger)
+        self.assertFalse(any(map(lambda p: os.path.exists(os.path.join(self.directory, p)), self.files)))
+        self.action.purge_files_and_folders([""], self.logger)
+        self.assertFalse(os.path.exists(self.directory))
+
+    def test_run(self):
+        directory_pattern = os.path.join("path", "to", "archive")
+        expected_directory = os.path.join("/data", socket.gethostname(), directory_pattern)
+        expected_output = filter(lambda p: p.startswith("too_old"), self.files)
+        self.action = PurgeRemoteFolders(directory_pattern, self.age_in_days, self.dryrun)
+        self.assertEqual(expected_directory, self.action.directory)
+        with mock.patch.object(
+                self.action, 'get_files_and_folders') as get_files_and_folders, mock.patch.object(
+                self.action, 'purge_files_and_folders') as purge_files_and_folders:
+            get_files_and_folders.return_value = expected_output
+            observed_output = self.action.purge(self.logger)
+            self.assertListEqual(expected_output, observed_output)
+            get_files_and_folders.assert_called_once_with()
+            purge_files_and_folders.assert_called_once_with(expected_output, self.logger)
+
+            # also, ensure that exceptions are handled properly
+            purge_files_and_folders.side_effect = IOError("key error raised by mock")
+            self.assertRaises(IOError, self.action.purge, self.logger)
+            get_files_and_folders.side_effect = ValueError("value error raised by mock")
+            self.assertRaises(ValueError, self.action.purge, self.logger)


### PR DESCRIPTION
**What problems does this PR solve?**
This PR introduces functionality for automatically do cleaning of processed (and archived) runfolders. 
This is done in two steps:

1 - after ngi_uu_workflow has successfully finished (the task `mark_as_finished` is successful), the bcl2fastq-created folder with fastq files on scratch is removed and the processed runfolder and staged archive are moved to the `Arkiverade` subfolder.

2 - a scheduled job runs once a week and removes any files and folders in the `Arkiverade` subfolders on the biotanks that have a modification date older than 30 days (the default value, can be configured).

**How has the changes been tested?**
The python script that removes folders has a test suite of unit tests and has been integration tested in a docker container, as well as being tested on staging. The workflow changes have been tested in the staging environment.

Before going into production, this should be validated. 

**Reasons for careful code review**
This code very much removes data and should therefore be carefully reviewed. In particular, watch out for conditions under which the intended paths to remove can be broken or truncated, resulting in removal of more data than intended. 

Additional safety precautions could be to move (or mount) the archive directory under a separate mount point.

  - [X] This PR contains code that could remove data
